### PR TITLE
Fix integer overflow bug in binary search

### DIFF
--- a/src/searching/mod.rs
+++ b/src/searching/mod.rs
@@ -7,7 +7,7 @@ pub fn binary_search<T>(item: T, arr: &[T]) -> i32
     let mut right = arr.len() - 1;
 
     while left < right {
-        let mid = (left + right) / 2;
+        let mid = left + (right - left) / 2;
 
         if arr[mid] > item {
             right = mid - 1;


### PR DESCRIPTION
`left + right` can be outside the range of 32bit numbers even if `left` and `right` are not. This can lead to bugs on 32bit systems. See [Nearly All Binary Searches and Mergesorts are Broken](https://ai.googleblog.com/2006/06/extra-extra-read-all-about-it-nearly.html).