### PR TITLE
Merge-sort

### DIFF
--- a/src/sorting/merge-sort.rs
+++ b/src/sorting/merge-sort.rs
@@ -1,0 +1,58 @@
+use std::iter::Peekable;
+use std::cmp::Ordering;
+
+struct MergeAscending<L, R>
+where
+    L: Iterator<Item = R::Item>,
+    R: Iterator,
+{
+    left: Peekable<L>,
+    right: Peekable<R>,
+}
+
+impl<L, R> MergeAscending<L, R>
+where
+    L: Iterator<Item = R::Item>,
+    R: Iterator,
+{
+    fn new(left: L, right: R) -> Self {
+        MergeAscending {
+            left: left.peekable(),
+            right: right.peekable(),
+        }
+    }
+}
+
+impl<L, R> Iterator for MergeAscending<L, R>
+where
+    L: Iterator<Item = R::Item>,
+    R: Iterator,
+    L::Item: Ord,
+{
+    type Item = L::Item;
+
+    fn next(&mut self) -> Option<L::Item> {
+        let which = match (self.left.peek(), self.right.peek()) {
+            (Some(l), Some(r)) => Some(l.cmp(r)),
+            (Some(_), None) => Some(Ordering::Less),
+            (None, Some(_)) => Some(Ordering::Greater),
+            (None, None) => None,
+        };
+
+        match which {
+            Some(Ordering::Less) => self.left.next(),
+            Some(Ordering::Equal) => self.left.next(),
+            Some(Ordering::Greater) => self.right.next(),
+            None => None,
+        }
+    }
+}
+
+fn main() {
+    let left = [1, 3, 5, 7, 9];
+    let right = [3, 4, 5, 6, 7];
+
+    let result: Vec<_> = MergeAscending::new(left.iter(), right.iter()).collect();
+    println("Sorted element ");
+    println!("{:?}", result);
+}


### PR DESCRIPTION
broke down method into two parts - one that determines from which side to pull, and one that actually advances that iterator.

**Merge sort** is a sorting technique based on **divide and conquer technique**. With worst-case time complexity being **Ο(n log n)**, it is one of the most respected algorithms. Merge sort first divides the array into equal halves and then combines them in a sorted manner.