### PR TITLE
added the already implemented selection sort to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ These are for demonstration purposes only.
 
 - [Bubble](./src/sorting/bubble_sort.rs)
 - [Counting](./src/sorting/counting_sort.rs)
+- [Heap](./src/sorting/heap_sort.rs)
 - [Insertion](./src/sorting/insertion_sort.rs)
 - Merge _(Not implemented yet)_
 - [Quick](./src/sorting/quick_sort.rs)
-- Selection _(Not implemented yet)_
-- [Shell](./src/sorting/shell_sort.rs)
-- [Heap](./src/sorting/heap_sort.rs)
 - Radix _(Not implemented yet)_
+- [Selection](./src/sorting/selection_sort.rs)
+- [Shell](./src/sorting/shell_sort.rs)
 
 ## Graphs
 

--- a/src/sorting/README.md
+++ b/src/sorting/README.md
@@ -15,6 +15,19 @@ __Properties__
 
 
 
+### [Counting](./counting_sort.rs)
+
+From [Wikipedia][selection-wiki]: In computer science, counting sort is an algorithm for sorting a collection of objects according to keys that are small integers; that is, it is an integer sorting algorithm. It operates by counting the number of objects that have each distinct key value, and using arithmetic on those counts to determine the positions of each key value in the output sequence. Its running time is linear in the number of items and the difference between the maximum and minimum key values, so it is only suitable for direct use in situations where the variation in keys is not significantly greater than the number of items. However, it is often used as a subroutine in another sorting algorithm, radix sort, that can handle larger keys more efficiently.
+
+__Properties__
+* Worst case performance	O(n+k)
+* Best case performance	O(n+k)
+* Average case performance	O(n+k),
+
+where n is the number of integers to sort and k is the difference between the largest and smallest integer in our list.
+
+
+
 ### [Insertion](./insertion_sort.rs)
 ![alt text][insertion-image]
 
@@ -53,7 +66,7 @@ __Properties__
 
 ###### View the algorithm in [action][quick-toptal]
 
-### Selection _(Not implemented yet)_
+### [Selection](./selection_sort.rs)
 ![alt text][selection-image]
 
 From [Wikipedia][selection-wiki]: The algorithm divides the input list into two parts: the sublist of items already sorted, which is built up from left to right at the front (left) of the list, and the sublist of items remaining to be sorted that occupy the rest of the list. Initially, the sorted sublist is empty and the unsorted sublist is the entire input list. The algorithm proceeds by finding the smallest (or largest, depending on sorting order) element in the unsorted sublist, exchanging (swapping) it with the leftmost unsorted element (putting it in sorted order), and moving the sublist boundaries one element to the right.
@@ -80,6 +93,8 @@ __Properties__
 [bubble-toptal]: https://www.toptal.com/developers/sorting-algorithms/bubble-sort
 [bubble-wiki]: https://en.wikipedia.org/wiki/Bubble_sort
 [bubble-image]: https://upload.wikimedia.org/wikipedia/commons/thumb/8/83/Bubblesort-edited-color.svg/220px-Bubblesort-edited-color.svg.png "Bubble Sort"
+
+[counting-wiki]: https://en.wikipedia.org/wiki/Counting_sort
 
 [insertion-toptal]: https://www.toptal.com/developers/sorting-algorithms/insertion-sort
 [insertion-wiki]: https://en.wikipedia.org/wiki/Insertion_sort


### PR DESCRIPTION
I've added an entry for Selection Sort to the documentation and fixed the alphabetical arrangement of all sorting algorithms.

Unfortunately, there was no picture for Selection Sort available on Wikipedia and no visualisation available on Toptal, so these spots remain empty.