### PR TITLE
Add Clippy to find common unidiomatic errors in the Rust code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: rust
 
 before_script:
   - rustup component add rustfmt-preview
+  - rustup component add clippy
 script:
   - cargo fmt --all -- --check
-  - cargo build
+  - cargo clippy
   - cargo test
-  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Algorithms - Rust [![Gitter](https://img.shields.io/gitter/room/the-algorithms/rust.svg?style=flat-square)](https://gitter.im/the-algorithms/rust)
+# The Algorithms - Rust [![Gitter](https://img.shields.io/gitter/room/the-algorithms/rust.svg?style=flat-square)](https://gitter.im/the-algorithms/rust) [![Build Status](https://travis-ci.org/TheAlgorithms/Rust.svg?branch=master)](https://travis-ci.org/TheAlgorithms/Rust)
 
 ### All algorithms implemented in Rust (for educational purposes)
 


### PR DESCRIPTION
Currently, there are numerous warnings; I can fix these if you want.