### PR TITLE
Add Vigenère cipher implementation

### DIFF
--- a/src/ciphers/mod.rs
+++ b/src/ciphers/mod.rs
@@ -1,3 +1,5 @@
 mod caesar;
+mod vigenere;
 
 pub use self::caesar::caesar;
+pub use self::vigenere::vigenere;

--- a/src/ciphers/vigenere.rs
+++ b/src/ciphers/vigenere.rs
@@ -9,10 +9,7 @@
 /// Vigenère cipher to rotate plain_text text by key and return an owned String.
 pub fn vigenere(plain_text: &str, key: &str) -> String {
     // Remove all unicode and non-ascii characters from key
-    let key: String = key
-        .chars()
-        .filter(|&c| c.is_ascii_alphabetic())
-        .collect();
+    let key: String = key.chars().filter(|&c| c.is_ascii_alphabetic()).collect();
     key.to_ascii_lowercase();
 
     let key_len = key.len();
@@ -49,22 +46,37 @@ mod tests {
 
     #[test]
     fn vigenere_base() {
-        assert_eq!(vigenere("LoremIpsumDolorSitAmet", "base"), "MojinIhwvmVsmojWjtSqft");
+        assert_eq!(
+            vigenere("LoremIpsumDolorSitAmet", "base"),
+            "MojinIhwvmVsmojWjtSqft"
+        );
     }
 
     #[test]
     fn vigenere_with_spaces() {
-        assert_eq!(vigenere("Lorem ipsum dolor sit amet, consectetur adipiscing elit.", "spaces"), "Ddrgq ahhuo hgddr uml sbev, ggfheexwljr chahxsemfy tlkx.");
+        assert_eq!(
+            vigenere(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                "spaces"
+            ),
+            "Ddrgq ahhuo hgddr uml sbev, ggfheexwljr chahxsemfy tlkx."
+        );
     }
 
     #[test]
     fn vigenere_unicode_and_numbers() {
-        assert_eq!(vigenere("1 Lorem ⏳ ipsum dolor sit amet Ѡ", "unicode"), "1 Fbzga ⏳ ltmhu fcosl fqv opin Ѡ");
+        assert_eq!(
+            vigenere("1 Lorem ⏳ ipsum dolor sit amet Ѡ", "unicode"),
+            "1 Fbzga ⏳ ltmhu fcosl fqv opin Ѡ"
+        );
     }
 
     #[test]
     fn vigenere_unicode_key() {
-        assert_eq!(vigenere("Lorem ipsum dolor sit amet", "😉 key!"), "Vspoq gzwsw hmvsp cmr kqcd");
+        assert_eq!(
+            vigenere("Lorem ipsum dolor sit amet", "😉 key!"),
+            "Vspoq gzwsw hmvsp cmr kqcd"
+        );
     }
 
     #[test]

--- a/src/ciphers/vigenere.rs
+++ b/src/ciphers/vigenere.rs
@@ -1,0 +1,74 @@
+//! Vigenère Cipher
+//!
+//! # Algorithm
+//!
+//! Rotate each ascii character by the offset of the corresponding key character.
+//! When we reach the last key character, we start over from the first one.
+//! This implementation does not rotate unicode characters.
+
+/// Vigenère cipher to rotate plain_text text by key and return an owned String.
+pub fn vigenere(plain_text: &str, key: &str) -> String {
+    // Remove all unicode and non-ascii characters from key
+    let key: String = key
+        .chars()
+        .filter(|&c| c.is_ascii_alphabetic())
+        .collect();
+    key.to_ascii_lowercase();
+
+    let key_len = key.len();
+    if key_len == 0 {
+        return String::from(plain_text);
+    }
+
+    let mut index = 0;
+
+    plain_text
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphabetic() {
+                let first = if c.is_ascii_lowercase() { b'a' } else { b'A' };
+                let shift = key.as_bytes()[index % key_len] - b'a';
+                index = index + 1;
+                // modulo the distance to keep character range
+                (first + (c as u8 + shift - first) % 26) as char
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        assert_eq!(vigenere("", "test"), "");
+    }
+
+    #[test]
+    fn vigenere_base() {
+        assert_eq!(vigenere("LoremIpsumDolorSitAmet", "base"), "MojinIhwvmVsmojWjtSqft");
+    }
+
+    #[test]
+    fn vigenere_with_spaces() {
+        assert_eq!(vigenere("Lorem ipsum dolor sit amet, consectetur adipiscing elit.", "spaces"), "Ddrgq ahhuo hgddr uml sbev, ggfheexwljr chahxsemfy tlkx.");
+    }
+
+    #[test]
+    fn vigenere_unicode_and_numbers() {
+        assert_eq!(vigenere("1 Lorem ⏳ ipsum dolor sit amet Ѡ", "unicode"), "1 Fbzga ⏳ ltmhu fcosl fqv opin Ѡ");
+    }
+
+    #[test]
+    fn vigenere_unicode_key() {
+        assert_eq!(vigenere("Lorem ipsum dolor sit amet", "😉 key!"), "Vspoq gzwsw hmvsp cmr kqcd");
+    }
+
+    #[test]
+    fn vigenere_empty_key() {
+        assert_eq!(vigenere("Lorem ipsum", ""), "Lorem ipsum");
+    }
+}


### PR DESCRIPTION
Added an implementation of the Vigenère cipher.

- skips all non-ascii characters from the key
- if key is empty, return the plain_text
- the key is case-insensitive
- all non-ascii characters from the plain_text are left untouched