### PR TITLE
"Merge Sort" without Clone

### DIFF
--- a/src/dynamic_programming/fibonacci.rs
+++ b/src/dynamic_programming/fibonacci.rs
@@ -9,7 +9,7 @@ pub fn fibonacci(n: u32) -> u128 {
     // Use a and b to store the previous two values in the sequence
     let mut a = 0;
     let mut b = 1;
-    for i in 0..n {
+    for _ in 0..n {
         // As we iterate through, move b's value into a and the new computed
         // value into b.
         let c = a + b;

--- a/src/sorting/merge_sort.rs
+++ b/src/sorting/merge_sort.rs
@@ -129,4 +129,29 @@ mod tests {
         merge_sort(&mut v);
         assert_eq!(v, answer);
     }
+
+    #[test]
+    fn no_clone() {
+        #[derive(Debug, PartialEq, Eq)]
+        struct Point {
+            x: u32,
+            y: u32,
+        }
+
+        let mut v = vec![];
+
+        v.push(Point { x: 10, y: 9 });
+        v.push(Point { x: 3, y: 8 });
+        v.push(Point { x: 8, y: 7 });
+
+        merge_sort_cmp(&mut v, |l, r| l.x < r.x);
+        assert_eq!(v[0], Point { x: 3, y: 8 });
+        assert_eq!(v[1], Point { x: 8, y: 7 });
+        assert_eq!(v[2], Point { x: 10, y: 9 });
+
+        merge_sort_cmp(&mut v, |l, r| l.y < r.y);
+        assert_eq!(v[0], Point { x: 8, y: 7 });
+        assert_eq!(v[1], Point { x: 3, y: 8 });
+        assert_eq!(v[2], Point { x: 10, y: 9 });
+    }
 }

--- a/src/sorting/merge_sort.rs
+++ b/src/sorting/merge_sort.rs
@@ -1,0 +1,124 @@
+pub fn merge_sort<T>(slice: &mut [T])
+where
+    T: Ord,
+{
+    merge_sort_cmp(slice, |a, b| a.lt(b));
+}
+
+pub fn merge_sort_cmp<T, F>(v: &mut [T], mut less: F)
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    if std::mem::size_of::<T>() == 0 {
+        return;
+    }
+
+    // Create a buffer with size `v.len() * size_of::<T>()` contains uninitialized data.
+    let mut buf = Vec::with_capacity(v.len());
+
+    sort_range(v, 0, v.len(), buf.as_mut_ptr(), &mut less);
+}
+
+fn sort_range<T, F>(v: &mut [T], begin: usize, end: usize, buf: *mut T, less: &mut F)
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    if end - begin <= 1 {
+        return;
+    }
+
+    let middle = (begin + end) / 2;
+
+    sort_range(v, begin, middle, buf, less);
+    sort_range(v, middle, end, buf, less);
+    merge(v, begin, middle, end, buf, less);
+}
+
+fn merge<T, F>(v: &mut [T], begin: usize, middle: usize, end: usize, buf: *mut T, mut less: F)
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    struct Range {
+        begin: usize,
+        end: usize,
+    }
+
+    let mut l = Range {
+        begin: begin,
+        end: middle,
+    };
+    let mut r = Range {
+        begin: middle,
+        end: end,
+    };
+    let mut top = unsafe { buf.add(begin) };
+
+    unsafe fn push<T>(top: &mut *mut T, data: *const T) {
+        std::ptr::copy_nonoverlapping(data, *top, 1);
+        *top = top.add(1);
+    }
+
+    while l.begin < l.end && r.begin < r.end {
+        if less(&v[l.begin], &v[r.begin]) {
+            unsafe { push(&mut top, &v[l.begin]) };
+            l.begin += 1;
+        } else {
+            unsafe { push(&mut top, &v[r.begin]) };
+            r.begin += 1;
+        }
+    }
+
+    for i in l.begin..l.end {
+        unsafe { push(&mut top, &v[i]) };
+    }
+    for i in r.begin..r.end {
+        unsafe { push(&mut top, &v[i]) };
+    }
+
+    unsafe {
+        std::ptr::copy_nonoverlapping(buf.add(begin), v.as_mut_ptr().add(begin), end - begin)
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn increase() {
+        let mut v = vec![1, 2, 3, 4];
+        let answer = v.clone();
+
+        merge_sort(&mut v);
+
+        assert_eq!(v, answer);
+    }
+
+    #[test]
+    fn decrease() {
+        let mut v = vec![4, 3, 2, 1];
+
+        let mut answer = v.clone();
+        answer.reverse();
+
+        merge_sort(&mut v);
+        assert_eq!(v, answer);
+    }
+
+    #[test]
+    fn urandom() {
+        let mut v = vec![];
+        let (mut x, a, c, m) = (0u64, 12, 34, 1_000_000_000 + 7);
+
+        for _ in 0..65536 {
+            x = (x + a) * c % m;
+            v.push(x);
+        }
+
+        let mut answer = v.clone();
+        answer.sort();
+
+        merge_sort(&mut v);
+        assert_eq!(v, answer);
+    }
+}

--- a/src/sorting/mod.rs
+++ b/src/sorting/mod.rs
@@ -2,6 +2,7 @@ mod bubble_sort;
 mod counting_sort;
 mod heap_sort;
 mod insertion;
+mod merge_sort;
 mod quick_sort;
 mod selection_sort;
 
@@ -12,6 +13,7 @@ pub use self::counting_sort::counting_sort;
 pub use self::counting_sort::generic_counting_sort;
 pub use self::heap_sort::heap_sort;
 pub use self::insertion::insertion_sort;
+pub use self::merge_sort::merge_sort;
 pub use self::quick_sort::quick_sort;
 pub use self::selection_sort::selection_sort;
 


### PR DESCRIPTION
Add a generic "Merge Sort" implemention.

This `merge_sort<T>(&mut [T])` do not requires `T: Clone`.

And some tests.