### PR TITLE
Adding Rust merge_sort (with tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These are for demonstration purposes only.
 - [Counting](./src/sorting/counting_sort.rs)
 - [Heap](./src/sorting/heap_sort.rs)
 - [Insertion](./src/sorting/insertion_sort.rs)
-- [Merge] _(.src/sorting/merge_sort.rs)_
+- [Merge](.src/sorting/merge_sort.rs)_
 - [Quick](./src/sorting/quick_sort.rs)
 - Radix _(Not implemented yet)_
 - [Selection](./src/sorting/selection_sort.rs)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These are for demonstration purposes only.
 - [Counting](./src/sorting/counting_sort.rs)
 - [Heap](./src/sorting/heap_sort.rs)
 - [Insertion](./src/sorting/insertion_sort.rs)
-- Merge _(Not implemented yet)_
+- [Merge] _(.src/sorting/merge_sort.rs)_
 - [Quick](./src/sorting/quick_sort.rs)
 - Radix _(Not implemented yet)_
 - [Selection](./src/sorting/selection_sort.rs)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These are for demonstration purposes only.
 - [Counting](./src/sorting/counting_sort.rs)
 - [Heap](./src/sorting/heap_sort.rs)
 - [Insertion](./src/sorting/insertion_sort.rs)
-- [Merge](.src/sorting/merge_sort.rs)_
+- [Merge](.src/sorting/merge_sort.rs)
 - [Quick](./src/sorting/quick_sort.rs)
 - Radix _(Not implemented yet)_
 - [Selection](./src/sorting/selection_sort.rs)

--- a/src/sorting/merge_sort.rs
+++ b/src/sorting/merge_sort.rs
@@ -1,0 +1,83 @@
+/// Merge Sort Algorithm
+/// Works for all Clone + Copy types (like primitive numbers)
+
+// Merge Sort
+pub fn merge_sort<T>(values: &[T]) -> Vec<T>
+where
+    T: PartialOrd + Clone + Copy,
+{
+    if values.len() <= 1 {
+        values.to_vec()
+    } else {
+        let mid = values.len() / 2;
+        merge(&merge_sort(&values[..mid]), &merge_sort(&values[mid..]))
+    }
+}
+
+// Merge two sorted slices
+// This is where the magic happens when merge_sort above is called
+// recursively until a starting slice is broken down into N Vecs of single items
+fn merge<T>(left: &[T], right: &[T]) -> Vec<T>
+where
+    T: PartialOrd + Clone + Copy,
+{
+    // The destination Vec to contain all items (sorted)
+    let mut merged = Vec::with_capacity(left.len() + right.len());
+    // Vec.remove(0) is expensive because it shifts all remaining
+    // items left. Instead, keep a cursor of position for each list
+    let (mut left_idx, mut right_idx) = (0, 0);
+    // Loop as long as each of the lists have remaining items
+    while (left_idx < left.len()) && (right_idx < right.len()) {
+        if &left[left_idx] < &right[right_idx] {
+            merged.push(left[left_idx]);
+            left_idx += 1;
+        } else {
+            merged.push(right[right_idx]);
+            right_idx += 1;
+        }
+    }
+    // Check to see which list has remaining items
+    if left_idx < left.len() {
+        merged.extend(&left[left_idx..]);
+    } else if right_idx < right.len() {
+        merged.extend(&right[right_idx..]);
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::is_sorted;
+    use super::*;
+
+    #[test]
+    fn test_merge_empty() {
+        let empty: Vec<u32> = Vec::new();
+        let result = merge_sort(&empty);
+        assert!(is_sorted(&result));
+    }
+    #[test]
+    fn test_merge_single() {
+        let result = merge_sort(&vec![5]);
+        assert!(is_sorted(&result));
+    }
+    #[test]
+    fn test_merge_sort() {
+        let values = vec![3, 1, 12, 4, 9, 2];
+        let result = merge_sort(&values);
+        assert!(is_sorted(&result));
+    }
+    #[test]
+    fn test_merge_already_sorted() {
+        let values = vec![1, 2, 3, 4, 9, 12];
+        let result = merge_sort(&values);
+        assert!(is_sorted(&result));
+    }
+
+    #[test]
+    fn test_merge_sort_with_negative() {
+        let values = vec![3, 1, 12, -2, 4, 9, 2, -10];
+        let result = merge_sort(&values);
+        assert!(is_sorted(&result));
+    }
+}

--- a/src/sorting/mod.rs
+++ b/src/sorting/mod.rs
@@ -2,6 +2,7 @@ mod bubble_sort;
 mod counting_sort;
 mod heap_sort;
 mod insertion;
+mod merge_sort;
 mod quick_sort;
 mod selection_sort;
 
@@ -12,6 +13,7 @@ pub use self::counting_sort::counting_sort;
 pub use self::counting_sort::generic_counting_sort;
 pub use self::heap_sort::heap_sort;
 pub use self::insertion::insertion_sort;
+pub use self::merge_sort::merge_sort;
 pub use self::quick_sort::quick_sort;
 pub use self::selection_sort::selection_sort;
 


### PR DESCRIPTION
Adding merge sort implementation, works for all Clone + Copy types. Also adding tests and updating the mod to include merge_sort.rs in test runs