### PR TITLE
[Feat] Add Radix Sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These are for demonstration purposes only.
 - [Insertion](./src/sorting/insertion_sort.rs)
 - [Merge](./src/sorting/merge_sort.rs)
 - [Quick](./src/sorting/quick_sort.rs)
-- Radix _(Not implemented yet)_
+- [Radix](./src/sorting/radix_sort.rs)
 - [Selection](./src/sorting/selection_sort.rs)
 - [Shell](./src/sorting/shell_sort.rs)
 

--- a/src/sorting/README.md
+++ b/src/sorting/README.md
@@ -66,6 +66,16 @@ __Properties__
 
 ###### View the algorithm in [action][quick-toptal]
 
+### [Radix](./radix_sort.rs)
+![alt text][radix-image]
+
+From [Wikipedia][radix-wiki]: Radix sort is a non-comparative sorting algorithm. It avoids comparison by creating and distributing elements into buckets according to their radix. For elements with more than one significant digit, this bucketing process is repeated for each digit, while preserving the ordering of the prior step, until all digits have been considered.
+
+__Properties__
+* Worst case performance O(w*n)
+
+where w is the number of bits required to store each key.
+
 ### [Selection](./selection_sort.rs)
 ![alt text][selection-image]
 
@@ -107,6 +117,9 @@ __Properties__
 [merge-toptal]: https://www.toptal.com/developers/sorting-algorithms/merge-sort
 [merge-wiki]: https://en.wikipedia.org/wiki/Merge_sort
 [merge-image]: https://upload.wikimedia.org/wikipedia/commons/c/cc/Merge-sort-example-300px.gif "Merge Sort"
+
+[radix-wiki]: https://en.wikipedia.org/wiki/Radix_sort
+[radix-image]: https://ds055uzetaobb.cloudfront.net/brioche/uploads/IEZs8xJML3-radixsort_ed.png?width=400 "Radix Sort"
 
 [selection-toptal]: https://www.toptal.com/developers/sorting-algorithms/selection-sort
 [selection-wiki]: https://en.wikipedia.org/wiki/Selection_sort

--- a/src/sorting/mod.rs
+++ b/src/sorting/mod.rs
@@ -4,6 +4,7 @@ mod heap_sort;
 mod insertion;
 mod merge_sort;
 mod quick_sort;
+mod radix_sort;
 mod selection_sort;
 
 use std::cmp;
@@ -15,6 +16,7 @@ pub use self::heap_sort::heap_sort;
 pub use self::insertion::insertion_sort;
 pub use self::merge_sort::merge_sort;
 pub use self::quick_sort::quick_sort;
+pub use self::radix_sort::radix_sort;
 pub use self::selection_sort::selection_sort;
 
 pub fn is_sorted<T>(arr: &[T]) -> bool

--- a/src/sorting/radix_sort.rs
+++ b/src/sorting/radix_sort.rs
@@ -11,13 +11,7 @@ pub fn radix_sort(arr: &mut [u64]) {
         None => return,
     };
     // Make radix a power of 2 close to arr.len() for optimal runtime
-    let radix = {
-        let mut r = 2;
-        while r < arr.len() {
-            r *= 2;
-        }
-        r
-    };
+    let radix = arr.len().next_power_of_two();
     // Counting sort by each digit from least to most significant
     let mut place = 1;
     while place <= max {

--- a/src/sorting/radix_sort.rs
+++ b/src/sorting/radix_sort.rs
@@ -1,0 +1,68 @@
+/// Sorts the elements of `arr` in-place using radix sort.
+///
+/// Time complexity is `O((n + b) * logb(k))`, where `n` is the number of elements,
+/// `b` is the base (the radix), and `k` is the largest element.
+/// When `n` and `b` are roughly the same maginitude, this algorithm runs in linear time.
+///
+/// Space complexity is `O(n + b)`.
+pub fn radix_sort(arr: &mut [u64]) {
+    let max: usize = match arr.iter().max() {
+        Some(&x) => x as usize,
+        None => return,
+    };
+    // Make radix a power of 2 close to arr.len() for optimal runtime
+    let radix = {
+        let mut r = 2;
+        while r < arr.len() {
+            r *= 2;
+        }
+        r
+    };
+    // Counting sort by each digit from least to most significant
+    let mut place = 1;
+    while place <= max {
+        let digit_of = |x| x as usize / place % radix;
+        // Count digit occurrences
+        let mut counter = vec![0; radix];
+        for &x in arr.iter() {
+            counter[digit_of(x)] += 1;
+        }
+        // Compute last index of each digit
+        for i in 1..radix {
+            counter[i] += counter[i - 1];
+        }
+        // Write elements to their new indices
+        for &x in arr.to_owned().iter().rev() {
+            counter[digit_of(x)] -= 1;
+            arr[counter[digit_of(x)]] = x;
+        }
+        place *= radix;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::is_sorted;
+    use super::radix_sort;
+
+    #[test]
+    fn empty() {
+        let mut a: [u64; 0] = [];
+        radix_sort(&mut a);
+        assert!(is_sorted(&a));
+    }
+
+    #[test]
+    fn descending() {
+        let mut v = vec![201, 127, 64, 37, 24, 4, 1];
+        radix_sort(&mut v);
+        assert!(is_sorted(&v));
+    }
+
+    #[test]
+    fn ascending() {
+        let mut v = vec![1, 4, 24, 37, 64, 127, 201];
+        radix_sort(&mut v);
+        assert!(is_sorted(&v));
+    }
+}


### PR DESCRIPTION
A radix sort implementation for issue #3.

I considered using the existing `counting_sort`, but I can't tell it what radix and digit to use when sorting.