### PR TITLE
Remove unnecessary heap allocation in heap data structure implementation

### DIFF
--- a/src/data_structures/heap.rs
+++ b/src/data_structures/heap.rs
@@ -10,14 +10,14 @@ where
 {
     count: usize,
     items: Vec<T>,
-    comparator: Box<dyn Fn(&T, &T) -> bool>,
+    comparator: fn(&T, &T) -> bool,
 }
 
 impl<T> Heap<T>
 where
     T: Default,
 {
-    pub fn new(comparator: Box<dyn Fn(&T, &T) -> bool>) -> Self {
+    pub fn new(comparator: fn(&T, &T) -> bool) -> Self {
         Self {
             count: 0,
             // Add a default in the first spot to offset indexes
@@ -113,8 +113,7 @@ impl MinHeap {
     where
         T: Default + Ord,
     {
-        let comparator = |a: &T, b: &T| a < b;
-        Heap::new(Box::new(comparator))
+        Heap::new(|a, b| a < b)
     }
 }
 
@@ -125,8 +124,7 @@ impl MaxHeap {
     where
         T: Default + Ord,
     {
-        let comparator = |a: &T, b: &T| a > b;
-        Heap::new(Box::new(comparator))
+        Heap::new(|a, b| a > b)
     }
 }
 
@@ -173,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_key_heap() {
-        let mut heap: Heap<Point> = Heap::new(Box::new(|a, b| a.0 < b.0));
+        let mut heap: Heap<Point> = Heap::new(|a, b| a.0 < b.0);
         heap.add(Point(1, 5));
         heap.add(Point(3, 10));
         heap.add(Point(-2, 4));


### PR DESCRIPTION
Current implementation of heap, min-heap and max-heap are using closures which are allocated dynamically on heap memory for comparing elements. However, they are not necessary to be closures here because a comparison predicate of heap data structure does not have its state. It's a pure function which takes two elements and returns boolean value. For such case, simply a function pointer is appropriate. It does not require any heap allocation.