### PR TITLE
Make unsafe blocks smaller

### DIFF
--- a/src/data_structures/linked_list.rs
+++ b/src/data_structures/linked_list.rs
@@ -40,20 +40,17 @@ impl<T> LinkedList<T> {
 
     pub fn add(&mut self, obj: T) {
         let mut node = Box::new(Node::new(obj));
-        unsafe {
-            // Since we are adding node at the end, next will always be None
-            node.next = None;
-            node.prev = self.end;
-            // Get a pointer to node
-            let node_ptr = Some(NonNull::new_unchecked(Box::into_raw(node)));
-            match self.end {
-                // This is the case of empty list
-                None => self.start = node_ptr,
-                Some(end_ptr) => (*end_ptr.as_ptr()).next = node_ptr,
-            }
-
-            self.end = node_ptr;
+        // Since we are adding node at the end, next will always be None
+        node.next = None;
+        node.prev = self.end;
+        // Get a pointer to node
+        let node_ptr = Some(unsafe { NonNull::new_unchecked(Box::into_raw(node)) });
+        match self.end {
+            // This is the case of empty list
+            None => self.start = node_ptr,
+            Some(end_ptr) => unsafe { (*end_ptr.as_ptr()).next = node_ptr },
         }
+        self.end = node_ptr;
         self.length += 1;
     }
 
@@ -62,14 +59,12 @@ impl<T> LinkedList<T> {
     }
 
     fn get_ith_node<'a>(&'a mut self, node: Option<NonNull<Node<T>>>, index: i32) -> Option<&'a T> {
-        unsafe {
-            match node {
-                None => None,
-                Some(next_ptr) => match index {
-                    0 => Some(&(*next_ptr.as_ptr()).val),
-                    _ => self.get_ith_node((*next_ptr.as_ptr()).next, index - 1),
-                },
-            }
+        match node {
+            None => None,
+            Some(next_ptr) => match index {
+                0 => Some(unsafe { &(*next_ptr.as_ptr()).val }),
+                _ => self.get_ith_node(unsafe { (*next_ptr.as_ptr()).next }, index - 1),
+            },
         }
     }
 }
@@ -79,11 +74,9 @@ where
     T: Display,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        unsafe {
-            match self.start {
-                Some(node) => write!(f, "{}", node.as_ref()),
-                None => write!(f, ""),
-            }
+        match self.start {
+            Some(node) => write!(f, "{}", unsafe { node.as_ref() }),
+            None => write!(f, ""),
         }
     }
 }
@@ -93,11 +86,9 @@ where
     T: Display,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        unsafe {
-            match self.next {
-                Some(node) => write!(f, "{}, {}", self.val, node.as_ref()),
-                None => write!(f, "{}", self.val),
-            }
+        match self.next {
+            Some(node) => write!(f, "{}, {}", self.val, unsafe { node.as_ref() }),
+            None => write!(f, "{}", self.val),
         }
     }
 }

--- a/src/data_structures/linked_list.rs
+++ b/src/data_structures/linked_list.rs
@@ -76,7 +76,7 @@ where
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self.start {
             Some(node) => write!(f, "{}", unsafe { node.as_ref() }),
-            None => write!(f, ""),
+            None => Ok(()),
         }
     }
 }


### PR DESCRIPTION
As the book says at https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html,

> People are fallible, and mistakes will happen, but by requiring these five unsafe operations to be inside blocks annotated with unsafe you’ll know that any errors related to memory safety must be within an unsafe block. Keep unsafe blocks small; you’ll be thankful later when you investigate memory bugs.

`unsafe` block should be as small as possible. Since this repository is a good showcase for learning Rust, I think following best practices is important. This PR changes usage of `unsafe` block to make them smaller.