### PR TITLE
Refactor BTreeProps::new, reducing verbosity.

### DIFF
--- a/src/data_structures/b_tree.rs
+++ b/src/data_structures/b_tree.rs
@@ -26,14 +26,8 @@ where
 {
     fn new(degree: usize, _keys: Option<Vec<T>>, _children: Option<Vec<Node<T>>>) -> Self {
         Node {
-            keys: match _keys {
-                Some(_keys) => _keys,
-                None => Vec::with_capacity(degree - 1),
-            },
-            children: match _children {
-                Some(_children) => _children,
-                None => Vec::with_capacity(degree),
-            },
+            keys: _keys.unwrap_or(Vec::with_capacity(degree - 1)),
+            children: _children.unwrap_or(Vec::with_capacity(degree)),
         }
     }
 


### PR DESCRIPTION
I found extraneous uses of matches and if-else's in the code, many of which can be replaced by chain-call styles. I think that improves readability and is more Rustacean. XD