### PR TITLE
fix URL of Closest pair in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Rust_programming_language_black_logo.svg/1024px-Rust_programming_language_black_logo.svg.png" width="200" height="200">
 
-
-
 ### All algorithms implemented in Rust (for educational purposes)
+
 These are for demonstration purposes only.
 
 ## [Sort Algorithms](./src/sorting)
@@ -20,6 +19,7 @@ These are for demonstration purposes only.
 - [x] [Shell](./src/sorting/shell_sort.rs)
 
 ## Graphs
+
 - [ ] Dijkstra
 - [ ] Kruskal's Minimum Spanning Tree
 - [x] [Prim's Minimum Spanning Tree](./src/graph/prim.rs)
@@ -73,7 +73,7 @@ These are for demonstration purposes only.
 
 ## [Geometry](./src/geometry)
 
-- [x] [Closest pair of 2D points](./src/searching/closest_points.rs)
+- [x] [Closest pair of 2D points](./src/geometry/closest_points.rs)
 
 ## [Ciphers](./src/ciphers)
 
@@ -86,7 +86,9 @@ These are for demonstration purposes only.
 ---
 
 ### All implemented Algos
+
 See [DIRECTORY.md](./DIRECTORY.md)
+
 ### Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### All algorithms implemented in Rust (for educational purposes)
 
 These are for demonstration purposes only.
-
+RESTART BUILD
 ## [Sort Algorithms](./src/sorting)
 
 - [x] [Bubble](./src/sorting/bubble_sort.rs)


### PR DESCRIPTION
I happened to find a expired URL in `README.md`, so I checked all the URL.
Fortunately, there is only one URL went wrong.

BTW: Yes, there is only one single line change (and a little empty line formatting) in this PR, please feel free to close it if it cause any trouble to commits history. 