### PR TITLE
Bucket sort implementation + inplace insertion sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ RESTART BUILD
 - [x] [Shell](./src/sorting/shell_sort.rs)
 - [x] [Stooge](./src/sorting/stooge_sort.rs)
 - [x] [Comb](./src/sorting/comb_sort.rs)
+- [x] [Bucket](./src/sorting/bucket_sort.rs)
 
 ## Graphs
 

--- a/src/sorting/bucket_sort.rs
+++ b/src/sorting/bucket_sort.rs
@@ -1,0 +1,80 @@
+/// Sort a slice using bucket sort algorithm.
+///
+/// Time complexity is `O(n + k)` on average, where `n` is the number of elements,
+/// `k` is the number of buckets used in process.
+///
+/// Space complexity is `O(n + k)`, as it sorts not in-place.
+pub fn bucket_sort(arr: &[usize]) -> Vec<usize> {
+    if arr.is_empty() {
+        return vec![];
+    }
+
+    let max = *arr.iter().max().unwrap();
+    let len = arr.len();
+    let mut buckets = vec![vec![]; len + 1];
+
+    for x in arr {
+        buckets[len * *x / max].push(*x);
+    }
+
+    for bucket in buckets.iter_mut() {
+        super::insertion_sort(bucket);
+    }
+
+    let mut result = vec![];
+    for bucket in buckets {
+        for x in bucket {
+            result.push(x);
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::is_sorted;
+    use super::*;
+
+    #[test]
+    fn empty() {
+        let arr: [usize; 0] = [];
+        let res = bucket_sort(&arr);
+        assert!(is_sorted(&res));
+    }
+
+    #[test]
+    fn one_element() {
+        let arr: [usize; 1] = [4];
+        let res = bucket_sort(&arr);
+        assert!(is_sorted(&res));
+    }
+
+    #[test]
+    fn already_sorted() {
+        let arr: [usize; 3] = [10, 9, 105];
+        let res = bucket_sort(&arr);
+        assert!(is_sorted(&res));
+    }
+
+    #[test]
+    fn basic() {
+        let arr: [usize; 4] = [35, 53, 1, 0];
+        let res = bucket_sort(&arr);
+        assert!(is_sorted(&res));
+    }
+
+    #[test]
+    fn odd_number_of_elements() {
+        let arr: Vec<usize> = vec![1, 21, 5, 11, 58];
+        let res = bucket_sort(&arr);
+        assert!(is_sorted(&res));
+    }
+
+    #[test]
+    fn repeated_elements() {
+        let arr: Vec<usize> = vec![542, 542, 542, 542];
+        let res = bucket_sort(&arr);
+        assert!(is_sorted(&res));
+    }
+}

--- a/src/sorting/insertion_sort.rs
+++ b/src/sorting/insertion_sort.rs
@@ -1,10 +1,12 @@
+use std::cmp;
+
 /// Sorts a mutable slice using in-place insertion sort algorithm.
 ///
 /// Time complexity is `O(n^2)`, where `n` is the number of elements.
 /// Space complexity is `O(1)` as it sorts elements in-place.
 pub fn insertion_sort<T>(arr: &mut [T])
 where
-    T: Ord + Copy,
+    T: cmp::PartialOrd + Copy,
 {
     for i in 1..arr.len() {
         let cur = arr[i];

--- a/src/sorting/insertion_sort.rs
+++ b/src/sorting/insertion_sort.rs
@@ -1,73 +1,69 @@
-use std::cmp;
-
-#[allow(dead_code)]
-pub fn insertion_sort<T>(arr: &[T]) -> Vec<T>
+/// Sorts a mutable slice using in-place insertion sort algorithm.
+///
+/// Time complexity is `O(n^2)`, where `n` is the number of elements.
+/// Space complexity is `O(1)` as it sorts elements in-place.
+pub fn insertion_sort<T>(arr: &mut [T])
 where
-    T: cmp::PartialEq + cmp::PartialOrd + Clone,
+    T: Ord + Copy,
 {
-    // The resulting vector should contain the same amount of elements as
-    // the slice that is being sorted, so enough room is preallocated
-    let mut result: Vec<T> = Vec::with_capacity(arr.len());
+    for i in 1..arr.len() {
+        let cur = arr[i];
+        let mut j = i - 1;
 
-    // Iterate over the elements to sort and
-    // put a clone of the element to insert in elem.
-    for elem in arr.iter().cloned() {
-        // How many elements have already been inserted?
-        let n_inserted = result.len();
-
-        // Loop over the inserted elements and one more index.
-        for i in 0..=n_inserted {
-            // If at the end or result[i] is larger than the current element,
-            // we have found the right spot:
-            if i == n_inserted || result[i] > elem {
-                // Insert the element at i,
-                // move the rest to higher indexes:
-                result.insert(i, elem);
+        while arr[j] > cur {
+            arr.swap(j + 1, j);
+            if j == 0 {
                 break;
             }
+            j -= 1;
         }
     }
-
-    result
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::is_sorted;
     use super::*;
 
     #[test]
     fn empty() {
-        let res = insertion_sort(&Vec::<u8>::new());
-        assert_eq!(res, vec![]);
+        let mut arr: [u8; 0] = [];
+        insertion_sort(&mut arr);
+        assert!(is_sorted(&arr));
     }
 
     #[test]
     fn one_element() {
-        let res = insertion_sort(&vec!["a"]);
-        assert_eq!(res, vec!["a"]);
+        let mut arr: [char; 1] = ['a'];
+        insertion_sort(&mut arr);
+        assert!(is_sorted(&arr));
     }
 
     #[test]
     fn already_sorted() {
-        let res = insertion_sort(&vec!["a", "b", "c"]);
-        assert_eq!(res, vec!["a", "b", "c"]);
+        let mut arr: [&str; 3] = ["a", "b", "c"];
+        insertion_sort(&mut arr);
+        assert!(is_sorted(&arr));
     }
 
     #[test]
     fn basic() {
-        let res = insertion_sort(&vec!["d", "a", "c", "b"]);
-        assert_eq!(res, vec!["a", "b", "c", "d"]);
+        let mut arr: [&str; 4] = ["d", "a", "c", "b"];
+        insertion_sort(&mut arr);
+        assert!(is_sorted(&arr));
     }
 
     #[test]
     fn odd_number_of_elements() {
-        let res = insertion_sort(&vec!["d", "a", "c", "e", "b"]);
-        assert_eq!(res, vec!["a", "b", "c", "d", "e"]);
+        let mut arr: Vec<&str> = vec!["d", "a", "c", "e", "b"];
+        insertion_sort(&mut arr);
+        assert!(is_sorted(&arr));
     }
 
     #[test]
     fn repeated_elements() {
-        let res = insertion_sort(&vec![542, 542, 542, 542]);
-        assert_eq!(res, vec![542, 542, 542, 542]);
+        let mut arr: Vec<usize> = vec![542, 542, 542, 542];
+        insertion_sort(&mut arr);
+        assert!(is_sorted(&arr));
     }
 }

--- a/src/sorting/mod.rs
+++ b/src/sorting/mod.rs
@@ -1,4 +1,5 @@
 mod bubble_sort;
+mod bucket_sort;
 mod cocktail_shaker_sort;
 mod comb_sort;
 mod counting_sort;
@@ -14,6 +15,7 @@ mod shell_sort;
 mod stooge_sort;
 
 pub use self::bubble_sort::bubble_sort;
+pub use self::bucket_sort::bucket_sort;
 pub use self::cocktail_shaker_sort::cocktail_shaker_sort;
 pub use self::comb_sort::comb_sort;
 pub use self::counting_sort::counting_sort;


### PR DESCRIPTION
This is a `bucket sort` algorithm implementation. 
As it is best to use `insertion sort` as a  subroutine of `bucket sort`, I went forward and improved the `insertion sort` version to one that sorts in-place.

So this PR includes:
* `bucket sort`
* in-place `insertion sort` re-write