### PR TITLE
Add methods and tests to LinkedList

### DIFF
--- a/src/data_structures/linked_list.rs
+++ b/src/data_structures/linked_list.rs
@@ -20,8 +20,8 @@ impl<T> Node<T> {
 
 pub struct LinkedList<T> {
     length: u32,
-    start: Option<NonNull<Node<T>>>,
-    end: Option<NonNull<Node<T>>>,
+    head: Option<NonNull<Node<T>>>,
+    tail: Option<NonNull<Node<T>>>,
     // Act like we own boxed nodes since we construct and leak them
     marker: PhantomData<Box<Node<T>>>,
 }
@@ -36,45 +36,149 @@ impl<T> LinkedList<T> {
     pub fn new() -> Self {
         Self {
             length: 0,
-            start: None,
-            end: None,
+            head: None,
+            tail: None,
             marker: PhantomData,
         }
     }
 
-    pub fn add(&mut self, obj: T) {
+    pub fn insert_at_head(&mut self, obj: T) {
         let mut node = Box::new(Node::new(obj));
-        // Since we are adding node at the end, next will always be None
-        node.next = None;
-        node.prev = self.end;
-        // Get a pointer to node
+        node.next = self.head;
+        node.prev = None;
         let node_ptr = Some(unsafe { NonNull::new_unchecked(Box::into_raw(node)) });
-        match self.end {
-            // This is the case of empty list
-            None => self.start = node_ptr,
-            Some(end_ptr) => unsafe { (*end_ptr.as_ptr()).next = node_ptr },
+        match self.head {
+            None => self.tail = node_ptr,
+            Some(head_ptr) => unsafe { (*head_ptr.as_ptr()).prev = node_ptr },
         }
-        self.end = node_ptr;
+        self.head = node_ptr;
         self.length += 1;
     }
 
-    pub fn pop_front(&mut self) -> Option<T> {
-        // Safety: start_ptr points to a leaked boxed node managed by this list
-        // We reassign pointers that pointed to the start node
-        self.start.map(|start_ptr| unsafe {
-            let old_start = Box::from_raw(start_ptr.as_ptr());
-            match old_start.next {
-                Some(mut next_ptr) => next_ptr.as_mut().prev = None,
-                None => self.end = None,
+    pub fn insert_at_tail(&mut self, obj: T) {
+        let mut node = Box::new(Node::new(obj));
+        node.next = None;
+        node.prev = self.tail;
+        let node_ptr = Some(unsafe { NonNull::new_unchecked(Box::into_raw(node)) });
+        match self.tail {
+            None => self.head = node_ptr,
+            Some(tail_ptr) => unsafe { (*tail_ptr.as_ptr()).next = node_ptr },
+        }
+        self.tail = node_ptr;
+        self.length += 1;
+    }
+
+    pub fn insert_at_ith(&mut self, index: u32, obj: T) {
+        if self.length < index {
+            panic!("Index out of bounds");
+        }
+
+        if index == 0 || self.head == None {
+            self.insert_at_head(obj);
+            return;
+        }
+
+        if self.length == index {
+            self.insert_at_tail(obj);
+            return;
+        }
+
+        if let Some(mut ith_node) = self.head {
+            for _ in 0..index {
+                unsafe {
+                    match (*ith_node.as_ptr()).next {
+                        None => panic!("Index out of bounds"),
+                        Some(next_ptr) => ith_node = next_ptr,
+                    }
+                }
             }
-            self.start = old_start.next;
+
+            let mut node = Box::new(Node::new(obj));
+            unsafe {
+                node.prev = (*ith_node.as_ptr()).prev;
+                node.next = Some(ith_node);
+                if let Some(p) = (*ith_node.as_ptr()).prev {
+                    let node_ptr = Some(NonNull::new_unchecked(Box::into_raw(node)));
+                    println!("{:?}", (*p.as_ptr()).next);
+                    (*p.as_ptr()).next = node_ptr;
+                    self.length += 1;
+                }
+            }
+        }
+    }
+
+    pub fn pop_head(&mut self) -> Option<T> {
+        // Safety: head_ptr points to a leaked boxed node managed by this list
+        // We reassign pointers that pointed to the head node
+        self.head.map(|head_ptr| unsafe {
+            let old_head = Box::from_raw(head_ptr.as_ptr());
+            match old_head.next {
+                Some(mut next_ptr) => next_ptr.as_mut().prev = None,
+                None => self.tail = None,
+            }
+            self.head = old_head.next;
             self.length -= 1;
-            old_start.val
+            old_head.val
         })
     }
 
+    pub fn pop_tail(&mut self) -> Option<T> {
+        // Safety: tail_ptr points to a leaked boxed node managed by this list
+        // We reassign pointers that pointed to the tail node
+        self.tail.map(|tail_ptr| unsafe {
+            let old_tail = Box::from_raw(tail_ptr.as_ptr());
+            match old_tail.prev {
+                Some(mut prev) => prev.as_mut().next = None,
+                None => self.head = None,
+            }
+            self.tail = old_tail.prev;
+            self.length -= 1;
+            old_tail.val
+        })
+    }
+
+    pub fn pop_ith(&mut self, index: u32) -> Option<T> {
+        if self.length < index {
+            panic!("Index out of bounds");
+        }
+
+        if index == 0 || self.head == None {
+            return self.pop_head();
+        }
+
+        if self.length == index {
+            return self.pop_tail();
+        }
+
+        if let Some(mut ith_node) = self.head {
+            for _ in 0..index {
+                unsafe {
+                    match (*ith_node.as_ptr()).next {
+                        None => panic!("Index out of bounds"),
+                        Some(next_ptr) => ith_node = next_ptr,
+                    }
+                }
+            }
+
+            unsafe {
+                let old_ith = Box::from_raw(ith_node.as_ptr());
+                if let Some(mut prev) = old_ith.prev {
+                    prev.as_mut().next = old_ith.next;
+                }
+                if let Some(mut next) = old_ith.next {
+                    next.as_mut().prev = old_ith.prev;
+                }
+
+                self.length -= 1;
+                Some(old_ith.val)
+            }
+        } else {
+            None
+        }
+    }
+
     pub fn get(&mut self, index: i32) -> Option<&T> {
-        self.get_ith_node(self.start, index)
+        self.get_ith_node(self.head, index)
     }
 
     fn get_ith_node(&mut self, node: Option<NonNull<Node<T>>>, index: i32) -> Option<&T> {
@@ -91,7 +195,7 @@ impl<T> LinkedList<T> {
 impl<T> Drop for LinkedList<T> {
     fn drop(&mut self) {
         // Pop items until there are none left
-        while self.pop_front().is_some() {}
+        while self.pop_head().is_some() {}
     }
 }
 
@@ -100,7 +204,7 @@ where
     T: Display,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self.start {
+        match self.head {
             Some(node) => write!(f, "{}", unsafe { node.as_ref() }),
             None => Ok(()),
         }
@@ -124,11 +228,170 @@ mod tests {
     use super::LinkedList;
 
     #[test]
+    fn insert_at_tail_works() {
+        let mut list = LinkedList::<i32>::new();
+        let second_value = 2;
+        list.insert_at_tail(1);
+        list.insert_at_tail(second_value);
+        println!("Linked List is {}", list);
+        match list.get(1) {
+            Some(val) => assert_eq!(*val, second_value),
+            None => panic!("Expected to find {} at index 1", second_value),
+        }
+    }
+    #[test]
+    fn insert_at_head_works() {
+        let mut list = LinkedList::<i32>::new();
+        let second_value = 2;
+        list.insert_at_head(1);
+        list.insert_at_head(second_value);
+        println!("Linked List is {}", list);
+        match list.get(0) {
+            Some(val) => assert_eq!(*val, second_value),
+            None => panic!("Expected to find {} at index 0", second_value),
+        }
+    }
+
+    #[test]
+    fn insert_at_ith_can_add_to_tail() {
+        let mut list = LinkedList::<i32>::new();
+        let second_value = 2;
+        list.insert_at_ith(0, 0);
+        list.insert_at_ith(1, second_value);
+        println!("Linked List is {}", list);
+        match list.get(1) {
+            Some(val) => assert_eq!(*val, second_value),
+            None => panic!("Expected to find {} at index 1", second_value),
+        }
+    }
+
+    #[test]
+    fn insert_at_ith_can_add_to_head() {
+        let mut list = LinkedList::<i32>::new();
+        let second_value = 2;
+        list.insert_at_ith(0, 1);
+        list.insert_at_ith(0, second_value);
+        println!("Linked List is {}", list);
+        match list.get(0) {
+            Some(val) => assert_eq!(*val, second_value),
+            None => panic!("Expected to find {} at index 0", second_value),
+        }
+    }
+
+    #[test]
+    fn insert_at_ith_can_add_to_middle() {
+        let mut list = LinkedList::<i32>::new();
+        let second_value = 2;
+        let third_value = 3;
+        list.insert_at_ith(0, 1);
+        list.insert_at_ith(1, second_value);
+        list.insert_at_ith(1, third_value);
+        println!("Linked List is {}", list);
+        match list.get(1) {
+            Some(val) => assert_eq!(*val, third_value),
+            None => panic!("Expected to find {} at index 1", third_value),
+        }
+
+        match list.get(2) {
+            Some(val) => assert_eq!(*val, second_value),
+            None => panic!("Expected to find {} at index 1", second_value),
+        }
+    }
+
+    #[test]
+    fn pop_tail_works() {
+        let mut list = LinkedList::<i32>::new();
+        let first_value = 1;
+        let second_value = 2;
+        list.insert_at_tail(first_value);
+        list.insert_at_tail(second_value);
+        match list.pop_tail() {
+            Some(val) => assert_eq!(val, 2),
+            None => panic!("Expected to remove {} at tail", second_value),
+        }
+
+        println!("Linked List is {}", list);
+        match list.get(0) {
+            Some(val) => assert_eq!(*val, first_value),
+            None => panic!("Expected to find {} at index 0", first_value),
+        }
+    }
+
+    #[test]
+    fn pop_head_works() {
+        let mut list = LinkedList::<i32>::new();
+        let first_value = 1;
+        let second_value = 2;
+        list.insert_at_tail(first_value);
+        list.insert_at_tail(second_value);
+        match list.pop_head() {
+            Some(val) => assert_eq!(val, 1),
+            None => panic!("Expected to remove {} at head", first_value),
+        }
+
+        println!("Linked List is {}", list);
+        match list.get(0) {
+            Some(val) => assert_eq!(*val, second_value),
+            None => panic!("Expected to find {} at index 0", second_value),
+        }
+    }
+
+    #[test]
+    fn pop_ith_can_pop_at_tail() {
+        let mut list = LinkedList::<i32>::new();
+        let first_value = 1;
+        let second_value = 2;
+        list.insert_at_tail(first_value);
+        list.insert_at_tail(second_value);
+        match list.pop_ith(1) {
+            Some(val) => assert_eq!(val, 2),
+            None => panic!("Expected to remove {} at tail", second_value),
+        }
+
+        assert_eq!(list.length, 1);
+    }
+
+    #[test]
+    fn pop_ith_can_pop_at_head() {
+        let mut list = LinkedList::<i32>::new();
+        let first_value = 1;
+        let second_value = 2;
+        list.insert_at_tail(first_value);
+        list.insert_at_tail(second_value);
+        match list.pop_ith(0) {
+            Some(val) => assert_eq!(val, 1),
+            None => panic!("Expected to remove {} at tail", first_value),
+        }
+
+        assert_eq!(list.length, 1);
+    }
+
+    #[test]
+    fn pop_ith_can_pop_in_middle() {
+        let mut list = LinkedList::<i32>::new();
+        let first_value = 1;
+        let second_value = 2;
+        let third_value = 3;
+        list.insert_at_tail(first_value);
+        list.insert_at_tail(second_value);
+        list.insert_at_tail(third_value);
+        match list.pop_ith(1) {
+            Some(val) => assert_eq!(val, 2),
+            None => panic!("Expected to remove {} at tail", second_value),
+        }
+
+        match list.get(1) {
+            Some(val) => assert_eq!(*val, third_value),
+            None => panic!("Expected to find {} at index 1", third_value),
+        }
+    }
+
+    #[test]
     fn create_numeric_list() {
         let mut list = LinkedList::<i32>::new();
-        list.add(1);
-        list.add(2);
-        list.add(3);
+        list.insert_at_tail(1);
+        list.insert_at_tail(2);
+        list.insert_at_tail(3);
         println!("Linked List is {}", list);
         assert_eq!(3, list.length);
     }
@@ -136,9 +399,9 @@ mod tests {
     #[test]
     fn create_string_list() {
         let mut list_str = LinkedList::<String>::new();
-        list_str.add("A".to_string());
-        list_str.add("B".to_string());
-        list_str.add("C".to_string());
+        list_str.insert_at_tail("A".to_string());
+        list_str.insert_at_tail("B".to_string());
+        list_str.insert_at_tail("C".to_string());
         println!("Linked List is {}", list_str);
         assert_eq!(3, list_str.length);
     }
@@ -146,8 +409,8 @@ mod tests {
     #[test]
     fn get_by_index_in_numeric_list() {
         let mut list = LinkedList::<i32>::new();
-        list.add(1);
-        list.add(2);
+        list.insert_at_tail(1);
+        list.insert_at_tail(2);
         println!("Linked List is {}", list);
         let retrived_item = list.get(1);
         assert!(retrived_item.is_some());
@@ -157,8 +420,8 @@ mod tests {
     #[test]
     fn get_by_index_in_string_list() {
         let mut list_str = LinkedList::<String>::new();
-        list_str.add("A".to_string());
-        list_str.add("B".to_string());
+        list_str.insert_at_tail("A".to_string());
+        list_str.insert_at_tail("B".to_string());
         println!("Linked List is {}", list_str);
         let retrived_item = list_str.get(1);
         assert!(retrived_item.is_some());

--- a/src/data_structures/linked_list.rs
+++ b/src/data_structures/linked_list.rs
@@ -107,7 +107,7 @@ impl<T> LinkedList<T> {
         }
     }
 
-    pub fn pop_head(&mut self) -> Option<T> {
+    pub fn delete_head(&mut self) -> Option<T> {
         // Safety: head_ptr points to a leaked boxed node managed by this list
         // We reassign pointers that pointed to the head node
         self.head.map(|head_ptr| unsafe {
@@ -122,7 +122,7 @@ impl<T> LinkedList<T> {
         })
     }
 
-    pub fn pop_tail(&mut self) -> Option<T> {
+    pub fn delete_tail(&mut self) -> Option<T> {
         // Safety: tail_ptr points to a leaked boxed node managed by this list
         // We reassign pointers that pointed to the tail node
         self.tail.map(|tail_ptr| unsafe {
@@ -137,17 +137,17 @@ impl<T> LinkedList<T> {
         })
     }
 
-    pub fn pop_ith(&mut self, index: u32) -> Option<T> {
+    pub fn delete_ith(&mut self, index: u32) -> Option<T> {
         if self.length < index {
             panic!("Index out of bounds");
         }
 
         if index == 0 || self.head == None {
-            return self.pop_head();
+            return self.delete_head();
         }
 
         if self.length == index {
-            return self.pop_tail();
+            return self.delete_tail();
         }
 
         if let Some(mut ith_node) = self.head {
@@ -195,7 +195,7 @@ impl<T> LinkedList<T> {
 impl<T> Drop for LinkedList<T> {
     fn drop(&mut self) {
         // Pop items until there are none left
-        while self.pop_head().is_some() {}
+        while self.delete_head().is_some() {}
     }
 }
 
@@ -301,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_at_ith_and_pop_ith_work_over_many_iterations() {
+    fn insert_at_ith_and_delete_ith_work_over_many_iterations() {
         let mut list = LinkedList::<i32>::new();
         for i in 0..100 {
             list.insert_at_ith(i, i.try_into().unwrap());
@@ -312,7 +312,7 @@ mod tests {
             println!("Popping {}", i);
             println!("list.length {}", list.length);
             if i % 2 == 0 {
-                list.pop_ith(i);
+                list.delete_ith(i);
             }
         }
 
@@ -336,13 +336,13 @@ mod tests {
     }
 
     #[test]
-    fn pop_tail_works() {
+    fn delete_tail_works() {
         let mut list = LinkedList::<i32>::new();
         let first_value = 1;
         let second_value = 2;
         list.insert_at_tail(first_value);
         list.insert_at_tail(second_value);
-        match list.pop_tail() {
+        match list.delete_tail() {
             Some(val) => assert_eq!(val, 2),
             None => panic!("Expected to remove {} at tail", second_value),
         }
@@ -355,13 +355,13 @@ mod tests {
     }
 
     #[test]
-    fn pop_head_works() {
+    fn delete_head_works() {
         let mut list = LinkedList::<i32>::new();
         let first_value = 1;
         let second_value = 2;
         list.insert_at_tail(first_value);
         list.insert_at_tail(second_value);
-        match list.pop_head() {
+        match list.delete_head() {
             Some(val) => assert_eq!(val, 1),
             None => panic!("Expected to remove {} at head", first_value),
         }
@@ -374,13 +374,13 @@ mod tests {
     }
 
     #[test]
-    fn pop_ith_can_pop_at_tail() {
+    fn delete_ith_can_delete_at_tail() {
         let mut list = LinkedList::<i32>::new();
         let first_value = 1;
         let second_value = 2;
         list.insert_at_tail(first_value);
         list.insert_at_tail(second_value);
-        match list.pop_ith(1) {
+        match list.delete_ith(1) {
             Some(val) => assert_eq!(val, 2),
             None => panic!("Expected to remove {} at tail", second_value),
         }
@@ -389,13 +389,13 @@ mod tests {
     }
 
     #[test]
-    fn pop_ith_can_pop_at_head() {
+    fn delete_ith_can_delete_at_head() {
         let mut list = LinkedList::<i32>::new();
         let first_value = 1;
         let second_value = 2;
         list.insert_at_tail(first_value);
         list.insert_at_tail(second_value);
-        match list.pop_ith(0) {
+        match list.delete_ith(0) {
             Some(val) => assert_eq!(val, 1),
             None => panic!("Expected to remove {} at tail", first_value),
         }
@@ -404,7 +404,7 @@ mod tests {
     }
 
     #[test]
-    fn pop_ith_can_pop_in_middle() {
+    fn delete_ith_can_delete_in_middle() {
         let mut list = LinkedList::<i32>::new();
         let first_value = 1;
         let second_value = 2;
@@ -412,7 +412,7 @@ mod tests {
         list.insert_at_tail(first_value);
         list.insert_at_tail(second_value);
         list.insert_at_tail(third_value);
-        match list.pop_ith(1) {
+        match list.delete_ith(1) {
             Some(val) => assert_eq!(val, 2),
             None => panic!("Expected to remove {} at tail", second_value),
         }

--- a/src/data_structures/linked_list.rs
+++ b/src/data_structures/linked_list.rs
@@ -307,9 +307,8 @@ mod tests {
             list.insert_at_ith(i, i.try_into().unwrap());
         }
 
-        // Pop even numbers
+        // Pop even numbers to 50
         for i in 0..50 {
-            println!("Popping {}", i);
             println!("list.length {}", list.length);
             if i % 2 == 0 {
                 list.delete_ith(i);
@@ -327,7 +326,7 @@ mod tests {
 
         assert_eq!(list.length, 100);
 
-        // Ensure numbers were restored and we're able to traverse nodes
+        // Ensure numbers were adderd back and we're able to traverse nodes
         if let Some(val) = list.get(78) {
             assert_eq!(*val, 78);
         } else {

--- a/src/data_structures/linked_list.rs
+++ b/src/data_structures/linked_list.rs
@@ -225,6 +225,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryInto;
+
     use super::LinkedList;
 
     #[test]
@@ -295,6 +297,41 @@ mod tests {
         match list.get(2) {
             Some(val) => assert_eq!(*val, second_value),
             None => panic!("Expected to find {} at index 1", second_value),
+        }
+    }
+
+    #[test]
+    fn insert_at_ith_and_pop_ith_work_over_many_iterations() {
+        let mut list = LinkedList::<i32>::new();
+        for i in 0..100 {
+            list.insert_at_ith(i, i.try_into().unwrap());
+        }
+
+        // Pop even numbers
+        for i in 0..50 {
+            println!("Popping {}", i);
+            println!("list.length {}", list.length);
+            if i % 2 == 0 {
+                list.pop_ith(i);
+            }
+        }
+
+        assert_eq!(list.length, 75);
+
+        // Insert even numbers back
+        for i in 0..50 {
+            if i % 2 == 0 {
+                list.insert_at_ith(i, i.try_into().unwrap());
+            }
+        }
+
+        assert_eq!(list.length, 100);
+
+        // Ensure numbers were restored and we're able to traverse nodes
+        if let Some(val) = list.get(78) {
+            assert_eq!(*val, 78);
+        } else {
+            panic!("Expected to find 78 at index 78");
         }
     }
 


### PR DESCRIPTION
Note: I also updated `start` and `end` syntax to `tail` and `head`. Sorry convoluting the PR. 

Methods changed:
`add` -> `insert_at_tail`
`pop_start`-> `delete_head`

Methods added:
`insert_at_head`
`insert_at_ith`
`delete_tail`
`delete_ith`

Tests added:
`insert_at_tail_works`
`insert_at_head_works`
`insert_at_ith_can_add_to_tail`
`insert_at_ith_can_add_to_head`
`insert_at_ith_can_add_to_middle`
`insert_at_ith_and_delete_ith_work_over_many_iterations`
`delete_tail_works`
`delete_head_works`
`delete_ith_can_pop_at_tail`
`delete_ith_can_pop_at_head`
`delete_ith_can_pop_in_middle`