### PR TITLE
Add Centroid Decomposition

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -56,6 +56,7 @@
     * [Disjoint Set Union](https://github.com/TheAlgorithms/Rust/blob/master/src/graph/disjoint_set_union.rs)
     * [Heavy Light Decomposition](https://github.com/TheAlgorithms/Rust/blob/master/src/graph/heavy_light_decomposition.rs)
     * [Tarjan's Strongly Connected Components](https://github.com/TheAlgorithms/Rust/blob/master/src/graph/strongly_connected_components.rs)
+    * [Centroid Decomposition](https://github.com/TheAlgorithms/Rust/blob/master/src/graph/centroid_decomposition.rs)
   * [Lib](https://github.com/TheAlgorithms/Rust/blob/master/src/lib.rs)
   * Math
     * [Baby-Step Giant-Step Algorithm](https://github.com/TheAlgorithms/Rust/blob/master/src/math/baby_step_giant_step.rs)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ These are for demonstration purposes only.
 - [x] [Heavy Light Decomposition](./src/graph/heavy_light_decomposition.rs)
 - [x] [Tarjan's Strongly Connected Components](./src/graph/strongly_connected_components.rs)
 - [x] [Topological sorting](./src/graph/topological_sort.rs)
+- [x] [Centroid Decomposition](./src/graph/centroid_decomposition.rs)
 
 ## [Math](./src/math)
 - [x] [Baby-Step Giant-Step Algorithm](./src/math/baby_step_giant_step.rs)

--- a/src/graph/centroid_decomposition.rs
+++ b/src/graph/centroid_decomposition.rs
@@ -37,10 +37,12 @@ impl CentroidDecomposition {
             vert_size: vec![0; num_vertices],
         }
     }
+    #[inline]
     fn put_in_decomposition(&mut self, v: usize, parent: usize) {
         self.decomposition[v] = parent;
         self.vert_state[v] |= IN_DECOMPOSITION;
     }
+    #[inline]
     fn is_in_decomposition(&self, v: usize) -> bool {
         (self.vert_state[v] & IN_DECOMPOSITION) != 0
     }
@@ -65,9 +67,8 @@ impl CentroidDecomposition {
     fn dfs_centroid(&self, v: usize, size_thr: usize) -> usize {
         // recurse until big child's size is <= `size_thr`
         match self.vert_state[v] as usize {
-            0 => v,
-            u if self.vert_size[u] > size_thr => self.dfs_centroid(u, size_thr),
-            _ => v,
+            u if self.vert_size[u] <= size_thr => v,
+            u => self.dfs_centroid(u, size_thr),
         }
     }
     fn decompose_subtree(

--- a/src/graph/centroid_decomposition.rs
+++ b/src/graph/centroid_decomposition.rs
@@ -1,0 +1,159 @@
+/*
+Centroid Decomposition for a tree.
+
+Given a tree, it can be recursively decomposed into centroids. Then the
+parent of a centroid `c` is the previous centroid that splitted its connected
+component into two or more components. It can be shown that in such
+decomposition, for each path `p` with starting and ending vertices `u`, `v`,
+the lowest common ancestor of `u` and `v` in centroid tree is a vertex of `p`.
+
+The input tree should have its vertices numbered from 1 to n, and
+`graph_enumeration.rs` may help to convert other representations.
+ */
+
+type Adj = [Vec<usize>];
+
+const IN_DECOMPOSITION: u64 = 1 << 63;
+pub struct CentroidDecomposition {
+    /// The root of the centroid tree, should _not_ be set by the user
+    pub root: usize,
+    /// The result. decomposition[`v`] is the parent of `v` in centroid tree.
+    /// decomposition[`root`] is 0
+    pub decomposition: Vec<usize>,
+    /// Used internally to save the big_child of a vertex, and whether it has
+    /// been added to the centroid tree.
+    vert_state: Vec<u64>,
+    /// Used internally to save the subtree size of a vertex
+    vert_size: Vec<usize>,
+}
+
+impl CentroidDecomposition {
+    pub fn new(mut num_vertices: usize) -> Self {
+        num_vertices += 1;
+        CentroidDecomposition {
+            root: 0,
+            decomposition: vec![0; num_vertices],
+            vert_state: vec![0; num_vertices],
+            vert_size: vec![0; num_vertices],
+        }
+    }
+    fn put_in_decomposition(&mut self, v: usize, parent: usize) {
+        self.decomposition[v] = parent;
+        self.vert_state[v] |= IN_DECOMPOSITION;
+    }
+    fn is_in_decomposition(&self, v: usize) -> bool {
+        (self.vert_state[v] & IN_DECOMPOSITION) != 0
+    }
+    fn dfs_size(&mut self, v: usize, parent: usize, adj: &Adj) -> usize {
+        self.vert_size[v] = 1;
+        let mut big_child = 0_usize;
+        let mut bc_size = 0_usize; // big child size
+        for &u in adj[v].iter() {
+            if u == parent || self.is_in_decomposition(u) {
+                continue;
+            }
+            let u_size = self.dfs_size(u, v, adj);
+            self.vert_size[v] += u_size;
+            if u_size > bc_size {
+                big_child = u;
+                bc_size = u_size;
+            }
+        }
+        self.vert_state[v] = big_child as u64;
+        self.vert_size[v]
+    }
+    fn dfs_centroid(&self, v: usize, size_thr: usize) -> usize {
+        // recurse until big child's size is <= `size_thr`
+        match self.vert_state[v] as usize {
+            0 => v,
+            u if self.vert_size[u] > size_thr => self.dfs_centroid(u, size_thr),
+            _ => v,
+        }
+    }
+    fn decompose_subtree(
+        &mut self,
+        v: usize,
+        centroid_parent: usize,
+        calculate_vert_size: bool,
+        adj: &Adj,
+    ) -> usize {
+        // `calculate_vert_size` determines if it is necessary to recalculate
+        // `self.vert_size`
+        if calculate_vert_size {
+            self.dfs_size(v, centroid_parent, adj);
+        }
+        let v_size = self.vert_size[v];
+        let centroid = self.dfs_centroid(v, v_size >> 1);
+        self.put_in_decomposition(centroid, centroid_parent);
+        for &u in adj[centroid].iter() {
+            if self.is_in_decomposition(u) {
+                continue;
+            }
+            self.decompose_subtree(
+                u,
+                centroid,
+                self.vert_size[u] > self.vert_size[centroid],
+                adj,
+            );
+        }
+        centroid
+    }
+    pub fn decompose_tree(&mut self, adj: &Adj) {
+        self.decompose_subtree(1, 0, true, adj);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CentroidDecomposition;
+    use crate::{
+        graph::{enumerate_graph, prufer_code},
+        math::PCG32,
+    };
+    fn calculate_height(v: usize, heights: &mut [usize], parents: &mut [usize]) -> usize {
+        if heights[v] == 0 {
+            heights[v] = calculate_height(parents[v], heights, parents) + 1;
+        }
+        heights[v]
+    }
+    #[test]
+    fn single_path() {
+        let len = 16;
+        let mut adj: Vec<Vec<usize>> = vec![vec![]; len];
+        adj[1].push(2);
+        adj[15].push(14);
+        for i in 2..15 {
+            adj[i].push(i + 1);
+            adj[i].push(i - 1);
+        }
+        let mut cd = CentroidDecomposition::new(len - 1);
+        cd.decompose_tree(&adj);
+        // We should get a complete binary tree
+        assert_eq!(
+            cd.decomposition,
+            vec![0, 2, 4, 2, 8, 6, 4, 6, 0, 10, 12, 10, 8, 14, 12, 14]
+        );
+    }
+    #[test]
+    #[ignore]
+    fn random_tree_height() {
+        // Do not run this test in debug mode! It takes > 30s to run without
+        // optimizations!
+        let n = 1e6 as usize;
+        let max_height = 1 + 20;
+        let len = n + 1;
+        let mut rng = PCG32::new_default(314159);
+        let mut tree_prufer_code: Vec<u32> = vec![0; n - 2];
+        tree_prufer_code.fill_with(|| (rng.get_u32() % (n as u32)) + 1);
+        let vertex_list: Vec<u32> = (1..=(n as u32)).collect();
+        let adj = enumerate_graph(&prufer_code::prufer_decode(&tree_prufer_code, &vertex_list));
+        let mut cd = CentroidDecomposition::new(n);
+        cd.decompose_tree(&adj);
+        let mut heights: Vec<usize> = vec![0; len];
+        heights[0] = 1;
+        for i in 1..=n {
+            let h = calculate_height(i, &mut heights, &mut cd.decomposition);
+            assert!(h <= max_height);
+        }
+    }
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,5 +1,6 @@
 mod bellman_ford;
 mod breadth_first_search;
+mod centroid_decomposition;
 mod depth_first_search;
 mod depth_first_search_tic_tac_toe;
 mod dijkstra;
@@ -15,6 +16,7 @@ mod topological_sort;
 
 pub use self::bellman_ford::bellman_ford;
 pub use self::breadth_first_search::breadth_first_search;
+pub use self::centroid_decomposition::CentroidDecomposition;
 pub use self::depth_first_search::depth_first_search;
 pub use self::depth_first_search_tic_tac_toe::minimax;
 pub use self::dijkstra::dijkstra;

--- a/src/graph/prufer_code.rs
+++ b/src/graph/prufer_code.rs
@@ -31,10 +31,12 @@ pub fn prufer_encode<V: Ord + Copy>(tree: &Graph<V>) -> Vec<V> {
     result
 }
 
+#[inline]
 fn add_directed_edge<V: Ord + Copy>(tree: &mut Graph<V>, a: V, b: V) {
     tree.entry(a).or_insert(vec![]).push(b);
 }
 
+#[inline]
 fn add_edge<V: Ord + Copy>(tree: &mut Graph<V>, a: V, b: V) {
     add_directed_edge(tree, a, b);
     add_directed_edge(tree, b, a);


### PR DESCRIPTION
My last test case took 35 secs on my own machine in unoptimized mode and 3.42 secs in optimized mode, so it must definitely be `[#ignore]`'ed. It is also pretty tight, to my own surprise; the theoretical `max_height` isn't too different from the actual result.

Side note: It is so satisfying to see a lot of the "infrastructure" we have added being used at the same time: `PCG32`, `prufer_code`, and `enumerate_graph`.

Edit: After some investigation, it seems like the code spends ~70% of its time in the test case to generate the tree, which makes sense as the Prufer code implementation cannot directly output the graph representation used here.