### PR TITLE
Prevent potential computing overflow in aho_corasick.rs.

### DIFF
--- a/src/string/aho_corasick.rs
+++ b/src/string/aho_corasick.rs
@@ -77,7 +77,7 @@ impl AhoCorasick {
                 }
             }
             for &len in &cur.borrow().lengths {
-                ans.push(&s[i - len + 1..=i]);
+                ans.push(&s[i + 1 - len..=i]);
             }
         }
         ans


### PR DESCRIPTION
As per issue #319, there was a chance of computing overflow due to the order of operations. This minor commit should fix that.