### PR TITLE
Improve time complexity of the old implementation of Rabin-Karp algo

### DIFF
--- a/src/string/rabin_karp.rs
+++ b/src/string/rabin_karp.rs
@@ -7,7 +7,7 @@ pub fn rabin_karp(target: String, pattern: String) -> Vec<usize> {
         return vec![];
     }
 
-    let pattern_hash = hash(&pattern.as_str());
+    let pattern_hash = hash(pattern.as_str());
 
     // Pre-calculate BASE^(n-1)
     let mut pow_rem: u16 = 1;


### PR DESCRIPTION
1. Compute the next hash value based on the previous one in constant time
  see [Rabin–Karp algorithm - Wikipedia](https://en.wikipedia.org/wiki/Rabin%E2%80%93Karp_algorithm#:~:text=For%20speed%2C%20the%20hash%20must%20be%20computed%20in%20constant%20time.)
2. Eliminate `clone` in code
3. Eliminate magic numbers
4. Improve variable naming, e.g. hash_pattern => pattern_hash to be more consistent with other variables