### PR TITLE
Fixed typo in comment of binary_search_tree.rs

### DIFF
--- a/src/data_structures/binary_search_tree.rs
+++ b/src/data_structures/binary_search_tree.rs
@@ -34,7 +34,7 @@ where
         }
     }
 
-    /// Find a value in this tree. Returns True iff value is in this
+    /// Find a value in this tree. Returns True if value is in this
     /// tree, and false otherwise
     pub fn search(&self, value: &T) -> bool {
         match &self.value {


### PR DESCRIPTION
I found a typo in a binary_search_tree.rs comment and thought I'd try my hand at fixing it. This is the first time I've ever tried contributing to something, any feedback on what to do better in the future would be greatly appreciated.