### PR TITLE
Add a generic HMAC struct and a Hashing trait

### DIFF
--- a/src/ciphers/hashing_traits.rs
+++ b/src/ciphers/hashing_traits.rs
@@ -1,68 +1,72 @@
 pub trait Hasher<const DIGEST_BYTES: usize> {
-	/// return a new instance with default parameters
-	fn new_default() -> Self;
+    /// return a new instance with default parameters
+    fn new_default() -> Self;
 
-	/// Add new data
-	fn update(&mut self, data: &[u8]);
+    /// Add new data
+    fn update(&mut self, data: &[u8]);
 
-	/// Use this to finish this block and start another one. If this block is
-	/// already full, nothing should be done
-	fn pad_buffer(&mut self);
+    /// Use this to finish this block and start another one. If this block is
+    /// already full, nothing should be done
+    fn pad_buffer(&mut self);
 
-	/// Returns the hash of current data. Calls `pad_buffer` on it and if
-	/// necessary does finalization work on the instance, thus it may no longer
-	/// make sense to do `update` after calling this.
-	fn get_hash(&mut self) -> [u8; DIGEST_BYTES];
+    /// Returns the hash of current data. Calls `pad_buffer` on it and if
+    /// necessary does finalization work on the instance, thus it may no longer
+    /// make sense to do `update` after calling this.
+    fn get_hash(&mut self) -> [u8; DIGEST_BYTES];
 }
 
 /// HMAC based on RFC2104, applicable to many cryptographic hash functions
 pub struct HMAC<const KEY_BYTES: usize, const DIGEST_BYTES: usize, H: Hasher<DIGEST_BYTES>> {
-	pub inner_internal_state: H,
-	pub outer_internal_state: H,
+    pub inner_internal_state: H,
+    pub outer_internal_state: H,
 }
 
-impl<const KEY_BYTES: usize, const DIGEST_BYTES: usize, H: Hasher<DIGEST_BYTES>> HMAC<KEY_BYTES, DIGEST_BYTES, H> {
-	pub fn new_default() -> Self {
-		HMAC {inner_internal_state: H::new_default(), outer_internal_state: H::new_default() }
-	}
+impl<const KEY_BYTES: usize, const DIGEST_BYTES: usize, H: Hasher<DIGEST_BYTES>>
+    HMAC<KEY_BYTES, DIGEST_BYTES, H>
+{
+    pub fn new_default() -> Self {
+        HMAC {
+            inner_internal_state: H::new_default(),
+            outer_internal_state: H::new_default(),
+        }
+    }
 
-	/// Note that `key` must be no longer than `KEY_BYTES`. According to RFC,
-	/// if it is so, you should replace it with its hash. We do not do this
-	/// automatically due to fear of `DIGEST_BYTES` not being the same as 
-	/// `KEY_BYTES`
-	pub fn add_key(&mut self, key: &[u8]) -> Result<(), &'static str> {
-		match key.len().cmp(&DIGEST_BYTES) {
-			std::cmp::Ordering::Less | std::cmp::Ordering::Equal => {
-				let mut tmp_key = [0u8; KEY_BYTES];
-				for (d, s) in tmp_key.iter_mut().zip(key.iter()){
-					*d = *s;
-				}
-				// key ^ 0x363636.. should be used as inner key
-				for b in tmp_key.iter_mut() {
-					*b ^= 0x36;
-				}
-				self.inner_internal_state.update(&tmp_key);
-				// key ^ 0x5c5c5c.. should be used as outer key, but the key is
-				// already XORed with 0x363636.. , so it must now be XORed with
-				// 0x6a6a6a..
-				for b in tmp_key.iter_mut() {
-					*b ^= 0x6a;
-				}
-				self.outer_internal_state.update(&tmp_key);
-				Ok(())
-			}
-			_ => {
-				Err("Key is longer than `KEY_BYTES`.")
-			}
-		}
-	}
+    /// Note that `key` must be no longer than `KEY_BYTES`. According to RFC,
+    /// if it is so, you should replace it with its hash. We do not do this
+    /// automatically due to fear of `DIGEST_BYTES` not being the same as
+    /// `KEY_BYTES`
+    pub fn add_key(&mut self, key: &[u8]) -> Result<(), &'static str> {
+        match key.len().cmp(&DIGEST_BYTES) {
+            std::cmp::Ordering::Less | std::cmp::Ordering::Equal => {
+                let mut tmp_key = [0u8; KEY_BYTES];
+                for (d, s) in tmp_key.iter_mut().zip(key.iter()) {
+                    *d = *s;
+                }
+                // key ^ 0x363636.. should be used as inner key
+                for b in tmp_key.iter_mut() {
+                    *b ^= 0x36;
+                }
+                self.inner_internal_state.update(&tmp_key);
+                // key ^ 0x5c5c5c.. should be used as outer key, but the key is
+                // already XORed with 0x363636.. , so it must now be XORed with
+                // 0x6a6a6a..
+                for b in tmp_key.iter_mut() {
+                    *b ^= 0x6a;
+                }
+                self.outer_internal_state.update(&tmp_key);
+                Ok(())
+            }
+            _ => Err("Key is longer than `KEY_BYTES`."),
+        }
+    }
 
-	pub fn update(&mut self, data: &[u8]) {
-		self.inner_internal_state.update(data);
-	}
+    pub fn update(&mut self, data: &[u8]) {
+        self.inner_internal_state.update(data);
+    }
 
-	pub fn finalize(&mut self) -> [u8; DIGEST_BYTES] {
-		self.outer_internal_state.update(&self.inner_internal_state.get_hash());
-		self.outer_internal_state.get_hash()
-	}
+    pub fn finalize(&mut self) -> [u8; DIGEST_BYTES] {
+        self.outer_internal_state
+            .update(&self.inner_internal_state.get_hash());
+        self.outer_internal_state.get_hash()
+    }
 }

--- a/src/ciphers/hashing_traits.rs
+++ b/src/ciphers/hashing_traits.rs
@@ -1,0 +1,68 @@
+pub trait Hasher<const DIGEST_BYTES: usize> {
+	/// return a new instance with default parameters
+	fn new_default() -> Self;
+
+	/// Add new data
+	fn update(&mut self, data: &[u8]);
+
+	/// Use this to finish this block and start another one. If this block is
+	/// already full, nothing should be done
+	fn pad_buffer(&mut self);
+
+	/// Returns the hash of current data. Calls `pad_buffer` on it and if
+	/// necessary does finalization work on the instance, thus it may no longer
+	/// make sense to do `update` after calling this.
+	fn get_hash(&mut self) -> [u8; DIGEST_BYTES];
+}
+
+/// HMAC based on RFC2104, applicable to many cryptographic hash functions
+pub struct HMAC<const KEY_BYTES: usize, const DIGEST_BYTES: usize, H: Hasher<DIGEST_BYTES>> {
+	pub inner_internal_state: H,
+	pub outer_internal_state: H,
+}
+
+impl<const KEY_BYTES: usize, const DIGEST_BYTES: usize, H: Hasher<DIGEST_BYTES>> HMAC<KEY_BYTES, DIGEST_BYTES, H> {
+	pub fn new_default() -> Self {
+		HMAC {inner_internal_state: H::new_default(), outer_internal_state: H::new_default() }
+	}
+
+	/// Note that `key` must be no longer than `KEY_BYTES`. According to RFC,
+	/// if it is so, you should replace it with its hash. We do not do this
+	/// automatically due to fear of `DIGEST_BYTES` not being the same as 
+	/// `KEY_BYTES`
+	pub fn add_key(&mut self, key: &[u8]) -> Result<(), &'static str> {
+		match key.len().cmp(&DIGEST_BYTES) {
+			std::cmp::Ordering::Less | std::cmp::Ordering::Equal => {
+				let mut tmp_key = [0u8; KEY_BYTES];
+				for (d, s) in tmp_key.iter_mut().zip(key.iter()){
+					*d = *s;
+				}
+				// key ^ 0x363636.. should be used as inner key
+				for b in tmp_key.iter_mut() {
+					*b ^= 0x36;
+				}
+				self.inner_internal_state.update(&tmp_key);
+				// key ^ 0x5c5c5c.. should be used as outer key, but the key is
+				// already XORed with 0x363636.. , so it must now be XORed with
+				// 0x6a6a6a..
+				for b in tmp_key.iter_mut() {
+					*b ^= 0x6a;
+				}
+				self.outer_internal_state.update(&tmp_key);
+				Ok(())
+			}
+			_ => {
+				Err("Key is longer than `KEY_BYTES`.")
+			}
+		}
+	}
+
+	pub fn update(&mut self, data: &[u8]) {
+		self.inner_internal_state.update(data);
+	}
+
+	pub fn finalize(&mut self) -> [u8; DIGEST_BYTES] {
+		self.outer_internal_state.update(&self.inner_internal_state.get_hash());
+		self.outer_internal_state.get_hash()
+	}
+}

--- a/src/ciphers/mod.rs
+++ b/src/ciphers/mod.rs
@@ -1,6 +1,7 @@
 mod aes;
 mod another_rot13;
 mod caesar;
+mod hashing_traits;
 mod morse_code;
 mod polybius;
 mod rot13;
@@ -10,11 +11,12 @@ mod theoretical_rot13;
 mod transposition;
 mod vigenere;
 mod xor;
-mod hashing_traits;
 
 pub use self::aes::{aes_decrypt, aes_encrypt, AesKey};
 pub use self::another_rot13::another_rot13;
 pub use self::caesar::caesar;
+pub use self::hashing_traits::Hasher;
+pub use self::hashing_traits::HMAC;
 pub use self::morse_code::{decode, encode};
 pub use self::polybius::{decode_ascii, encode_ascii};
 pub use self::rot13::rot13;
@@ -24,5 +26,3 @@ pub use self::theoretical_rot13::theoretical_rot13;
 pub use self::transposition::transposition;
 pub use self::vigenere::vigenere;
 pub use self::xor::xor;
-pub use self::hashing_traits::Hasher;
-pub use self::hashing_traits::HMAC;

--- a/src/ciphers/mod.rs
+++ b/src/ciphers/mod.rs
@@ -20,7 +20,7 @@ pub use self::hashing_traits::HMAC;
 pub use self::morse_code::{decode, encode};
 pub use self::polybius::{decode_ascii, encode_ascii};
 pub use self::rot13::rot13;
-pub use self::sha256::sha256;
+pub use self::sha256::SHA256;
 pub use self::tea::{tea_decrypt, tea_encrypt};
 pub use self::theoretical_rot13::theoretical_rot13;
 pub use self::transposition::transposition;

--- a/src/ciphers/mod.rs
+++ b/src/ciphers/mod.rs
@@ -10,6 +10,7 @@ mod theoretical_rot13;
 mod transposition;
 mod vigenere;
 mod xor;
+mod hashing_traits;
 
 pub use self::aes::{aes_decrypt, aes_encrypt, AesKey};
 pub use self::another_rot13::another_rot13;
@@ -23,3 +24,5 @@ pub use self::theoretical_rot13::theoretical_rot13;
 pub use self::transposition::transposition;
 pub use self::vigenere::vigenere;
 pub use self::xor::xor;
+pub use self::hashing_traits::Hasher;
+pub use self::hashing_traits::HMAC;

--- a/src/ciphers/sha256.rs
+++ b/src/ciphers/sha256.rs
@@ -1,154 +1,266 @@
-//! SHA-2 (256 Bit)
+/*!
+ * SHA-2 256 bit implementation
+ * This implementation is based on RFC6234
+ * Keep in mind that the amount of data (in bits) processed should always be an
+ * integer multiple of 8
+ */
 
-struct BufState {
-    data: Vec<u8>,
-    len: usize,
-    total_len: usize,
-    single: bool,
-    total: bool,
+use std::fmt::Write;
+
+// The constants are tested to make sure they are correct
+pub const H0: [u32; 8] = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+];
+
+pub const K: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+// The following functions are implemented according to page 10 of RFC6234
+#[inline]
+fn ch(x: u32, y: u32, z: u32) -> u32 {
+    (x & y) ^ ((!x) & z)
 }
 
-pub fn sha256(data: &[u8]) -> [u8; 32] {
-    let mut hash: [u8; 32] = [0; 32];
+#[inline]
+fn maj(x: u32, y: u32, z: u32) -> u32 {
+    (x & y) ^ (x & z) ^ (y & z)
+}
 
-    let mut h: [u32; 8] = [
-        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
-        0x5be0cd19,
-    ];
+#[inline]
+fn bsig0(x: u32) -> u32 {
+    x.rotate_right(2) ^ x.rotate_right(13) ^ x.rotate_right(22)
+}
 
-    let k: [u32; 64] = [
-        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
-        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
-        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
-        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
-        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
-        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
-        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
-        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
-        0xc67178f2,
-    ];
+#[inline]
+fn bsig1(x: u32) -> u32 {
+    x.rotate_right(6) ^ x.rotate_right(11) ^ x.rotate_right(25)
+}
 
-    let mut chunk: [u8; 64] = [0; 64];
+#[inline]
+fn ssig0(x: u32) -> u32 {
+    x.rotate_right(7) ^ x.rotate_right(18) ^ (x >> 3)
+}
 
-    let mut state: BufState = BufState {
-        data: (*data).to_owned(),
-        len: data.len(),
-        total_len: data.len(),
-        single: false,
-        total: false,
-    };
+#[inline]
+fn ssig1(x: u32) -> u32 {
+    x.rotate_right(17) ^ x.rotate_right(19) ^ (x >> 10)
+}
 
-    while calc_chunk(&mut chunk, &mut state) {
-        let mut ah: [u32; 8] = h;
-        let mut w: [u32; 16] = [0; 16];
-        for i in 0..4 {
-            for j in 0..16 {
-                if i == 0 {
-                    w[j] = ((chunk[j * 4] as u32) << 24)
-                        | ((chunk[j * 4 + 1] as u32) << 16)
-                        | ((chunk[j * 4 + 2] as u32) << 8)
-                        | (chunk[j * 4 + 3] as u32);
-                } else {
-                    let s0 = (w[(j + 1) & 0xf].rotate_right(7) ^ w[(j + 1) & 0xf].rotate_right(18))
-                        ^ (w[(j + 1) & 0xf] >> 3);
-                    let s1 = w[(j + 14) & 0xf].rotate_right(17)
-                        ^ w[(j + 14) & 0xf].rotate_right(19)
-                        ^ (w[(j + 14) & 0xf] >> 10);
-                    w[j] = w[j]
-                        .wrapping_add(s0)
-                        .wrapping_add(w[(j + 9) & 0xf])
-                        .wrapping_add(s1);
+pub struct SHA256 {
+    /// The current block to be processed, 512 bits long
+    buffer: [u32; 16],
+    /// Length (bits) of the message, should always be a multiple of 8
+    length: u64,
+    /// The current hash value. Note: this value is invalid unless `finalize`
+    /// is called
+    pub h: [u32; 8],
+    /// Message schedule
+    w: [u32; 64],
+    pub finalized: bool,
+    // Temporary values:
+    round: [u32; 8],
+}
+
+fn process_block(h: &mut [u32; 8], w: &mut [u32; 64], round: &mut [u32; 8], buf: &[u32; 16]) {
+    // Prepare the message schedule:
+    w[..buf.len()].copy_from_slice(&buf[..]);
+    for i in buf.len()..w.len() {
+        w[i] = ssig1(w[i - 2])
+            .wrapping_add(w[i - 7])
+            .wrapping_add(ssig0(w[i - 15]))
+            .wrapping_add(w[i - 16]);
+    }
+    round.copy_from_slice(h);
+    for i in 0..w.len() {
+        let t1 = round[7]
+            .wrapping_add(bsig1(round[4]))
+            .wrapping_add(ch(round[4], round[5], round[6]))
+            .wrapping_add(K[i])
+            .wrapping_add(w[i]);
+        let t2 = bsig0(round[0]).wrapping_add(maj(round[0], round[1], round[2]));
+        round[7] = round[6];
+        round[6] = round[5];
+        round[5] = round[4];
+        round[4] = round[3].wrapping_add(t1);
+        round[3] = round[2];
+        round[2] = round[1];
+        round[1] = round[0];
+        round[0] = t1.wrapping_add(t2);
+    }
+    for i in 0..h.len() {
+        h[i] = h[i].wrapping_add(round[i]);
+    }
+}
+
+#[allow(dead_code)]
+// Let's keep this utility function
+pub fn get_hash_string(hash: &[u8; 32]) -> String {
+    let mut result = String::new();
+    result.reserve(64);
+    for &ch in hash {
+        write!(&mut result, "{ch:02x}").unwrap();
+    }
+    result
+}
+
+impl SHA256 {
+    pub fn new_default() -> Self {
+        SHA256 {
+            buffer: [0u32; 16],
+            length: 0,
+            h: H0,
+            w: [0u32; 64],
+            round: [0u32; 8],
+            finalized: false,
+        }
+    }
+    /// Note: buffer should be empty before calling this!
+    pub fn process_block(&mut self, buf: &[u32; 16]) {
+        process_block(&mut self.h, &mut self.w, &mut self.round, buf);
+        self.length += 512;
+    }
+
+    pub fn update(&mut self, data: &[u8]) {
+        if data.is_empty() {
+            return;
+        }
+        let offset = (((32 - (self.length & 31)) & 31) >> 3) as usize;
+        let mut buf_ind = ((self.length & 511) >> 5) as usize;
+        for (i, &byte) in data.iter().enumerate().take(offset) {
+            self.buffer[buf_ind] ^= (byte as u32) << ((offset - i - 1) << 3);
+        }
+        self.length += (data.len() as u64) << 3;
+        if offset > data.len() {
+            return;
+        }
+        if offset > 0 {
+            buf_ind += 1;
+        }
+        if data.len() > 3 {
+            for i in (offset..(data.len() - 3)).step_by(4) {
+                if buf_ind & 16 == 16 {
+                    process_block(&mut self.h, &mut self.w, &mut self.round, &self.buffer);
+                    buf_ind = 0;
                 }
-
-                let s1: u32 =
-                    ah[4].rotate_right(6) ^ ah[4].rotate_right(11) ^ ah[4].rotate_right(25);
-                let ch: u32 = (ah[4] & ah[5]) ^ (!ah[4] & ah[6]);
-                let temp1: u32 = ah[7]
-                    .wrapping_add(s1)
-                    .wrapping_add(ch)
-                    .wrapping_add(k[i << 4 | j])
-                    .wrapping_add(w[j]);
-                let s0: u32 =
-                    ah[0].rotate_right(2) ^ ah[0].rotate_right(13) ^ ah[0].rotate_right(22);
-                let maj: u32 = (ah[0] & ah[1]) ^ (ah[0] & ah[2]) ^ (ah[1] & ah[2]);
-                let temp2: u32 = s0.wrapping_add(maj);
-
-                ah[7] = ah[6];
-                ah[6] = ah[5];
-                ah[5] = ah[4];
-                ah[4] = ah[3].wrapping_add(temp1);
-                ah[3] = ah[2];
-                ah[2] = ah[1];
-                ah[1] = ah[0];
-                ah[0] = temp1.wrapping_add(temp2);
+                self.buffer[buf_ind] = ((data[i] as u32) << 24)
+                    ^ ((data[i + 1] as u32) << 16)
+                    ^ ((data[i + 2] as u32) << 8)
+                    ^ data[i + 3] as u32;
+                buf_ind += 1;
             }
         }
-
-        for i in 0..8 {
-            h[i] = h[i].wrapping_add(ah[i]);
+        if buf_ind & 16 == 16 {
+            process_block(&mut self.h, &mut self.w, &mut self.round, &self.buffer);
+            buf_ind = 0;
         }
-        chunk = [0; 64];
+        self.buffer[buf_ind] = 0;
+        let rem_ind = offset + ((data.len() - offset) & !0b11);
+        for (i, &byte) in data[rem_ind..].iter().enumerate() {
+            self.buffer[buf_ind] ^= (byte as u32) << ((3 - i) << 3);
+        }
     }
 
-    for i in 0..8 {
-        hash[i * 4] = (h[i] >> 24) as u8;
-        hash[i * 4 + 1] = (h[i] >> 16) as u8;
-        hash[i * 4 + 2] = (h[i] >> 8) as u8;
-        hash[i * 4 + 3] = h[i] as u8;
+    pub fn get_hash(&mut self) -> [u8; 32] {
+        // we should first add a `1` bit to the end of the buffer, then we will
+        // add enough 0s so that the length becomes (512k + 448). After that we
+        // will append the binary representation of length to the data
+        if !self.finalized {
+            self.finalized = true;
+            let clen = (self.length + 8) & 511;
+            let num_0 = match clen.cmp(&448) {
+                std::cmp::Ordering::Greater => (448 + 512 - clen) >> 3,
+                _ => (448 - clen) >> 3,
+            };
+            let mut padding: Vec<u8> = vec![0_u8; (num_0 + 9) as usize];
+            let len = padding.len();
+            padding[0] = 0x80;
+            padding[len - 8] = (self.length >> 56) as u8;
+            padding[len - 7] = (self.length >> 48) as u8;
+            padding[len - 6] = (self.length >> 40) as u8;
+            padding[len - 5] = (self.length >> 32) as u8;
+            padding[len - 4] = (self.length >> 24) as u8;
+            padding[len - 3] = (self.length >> 16) as u8;
+            padding[len - 2] = (self.length >> 8) as u8;
+            padding[len - 1] = self.length as u8;
+            self.update(&padding);
+        }
+        assert_eq!(self.length & 511, 0);
+        let mut result = [0u8; 32];
+        for i in (0..32).step_by(4) {
+            result[i] = (self.h[i >> 2] >> 24) as u8;
+            result[i + 1] = (self.h[i >> 2] >> 16) as u8;
+            result[i + 2] = (self.h[i >> 2] >> 8) as u8;
+            result[i + 3] = self.h[i >> 2] as u8;
+        }
+        result
     }
-
-    hash
 }
 
-fn calc_chunk(chunk: &mut [u8; 64], state: &mut BufState) -> bool {
-    if state.total {
-        return false;
+impl super::Hasher<32> for SHA256 {
+    fn new_default() -> Self {
+        SHA256::new_default()
     }
 
-    if state.len >= 64 {
-        for x in chunk {
-            *x = state.data[0];
-            state.data.remove(0);
-        }
-        state.len -= 64;
-        return true;
+    fn update(&mut self, data: &[u8]) {
+        self.update(data);
     }
 
-    let remaining: usize = state.data.len();
-    let space: usize = 64 - remaining;
-    for x in chunk.iter_mut().take(state.data.len()) {
-        *x = state.data[0];
-        state.data.remove(0);
+    fn get_hash(&mut self) -> [u8; 32] {
+        self.get_hash()
     }
-
-    if !state.single {
-        chunk[remaining] = 0x80;
-        state.single = true;
-    }
-
-    if space >= 8 {
-        let mut len = state.total_len;
-        chunk[63] = (len << 3) as u8;
-        len >>= 5;
-        for i in 1..8 {
-            chunk[(63 - i)] = len as u8;
-            len >>= 8;
-        }
-        state.total = true;
-    }
-
-    true
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::math::LinearSieve;
+
+    #[test]
+    fn test_constants() {
+        let mut ls = LinearSieve::new();
+        ls.prepare(311).unwrap();
+        assert_eq!(64, ls.primes.len());
+        assert_eq!(311, ls.primes[63]);
+
+        let float_len = 52;
+        let constant_len = 32;
+        for (pos, &k) in K.iter().enumerate() {
+            let a: f64 = ls.primes[pos] as f64;
+            let bits = a.cbrt().to_bits();
+            let exp = bits >> float_len; // The sign bit is already 0
+                                         //(exp - 1023) can be bigger than 0, we must include more bits.
+            let k_ref = ((bits & ((1_u64 << float_len) - 1))
+                >> (float_len - constant_len + 1023 - exp)) as u32;
+            assert_eq!(k, k_ref);
+        }
+
+        for (pos, &h) in H0.iter().enumerate() {
+            let a: f64 = ls.primes[pos] as f64;
+            let bits = a.sqrt().to_bits();
+            let exp = bits >> float_len;
+            let h_ref = ((bits & ((1_u64 << float_len) - 1))
+                >> (float_len - constant_len + 1023 - exp)) as u32;
+            assert_eq!(h, h_ref);
+        }
+    }
+
+    // To test the hashes, you can use the following command on linux:
+    // echo -n 'STRING' | sha256sum
+    // the `-n` is because by default, echo adds a `\n` to its output
 
     #[test]
     fn empty() {
+        let mut res = SHA256::new_default();
         assert_eq!(
-            sha256(&Vec::new()),
+            res.get_hash(),
             [
                 0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f,
                 0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b,
@@ -159,8 +271,10 @@ mod tests {
 
     #[test]
     fn ascii() {
+        let mut res = SHA256::new_default();
+        res.update(&b"The quick brown fox jumps over the lazy dog".to_vec());
         assert_eq!(
-            sha256(&b"The quick brown fox jumps over the lazy dog".to_vec()),
+            res.get_hash(),
             [
                 0xD7, 0xA8, 0xFB, 0xB3, 0x07, 0xD7, 0x80, 0x94, 0x69, 0xCA, 0x9A, 0xBC, 0xB0, 0x08,
                 0x2E, 0x4F, 0x8D, 0x56, 0x51, 0xE4, 0x6D, 0x3C, 0xDB, 0x76, 0x2D, 0x02, 0xD0, 0xBF,
@@ -171,13 +285,58 @@ mod tests {
 
     #[test]
     fn ascii_avalanche() {
+        let mut res = SHA256::new_default();
+        res.update(&b"The quick brown fox jumps over the lazy dog.".to_vec());
         assert_eq!(
-            sha256(&b"The quick brown fox jumps over the lazy dog.".to_vec()),
+            res.get_hash(),
+            [
+                0xEF, 0x53, 0x7F, 0x25, 0xC8, 0x95, 0xBF, 0xA7, 0x82, 0x52, 0x65, 0x29, 0xA9, 0xB6,
+                0x3D, 0x97, 0xAA, 0x63, 0x15, 0x64, 0xD5, 0xD7, 0x89, 0xC2, 0xB7, 0x65, 0x44, 0x8C,
+                0x86, 0x35, 0xFB, 0x6C
+            ]
+        );
+        // Test if finalization is not repeated twice
+        assert_eq!(
+            res.get_hash(),
             [
                 0xEF, 0x53, 0x7F, 0x25, 0xC8, 0x95, 0xBF, 0xA7, 0x82, 0x52, 0x65, 0x29, 0xA9, 0xB6,
                 0x3D, 0x97, 0xAA, 0x63, 0x15, 0x64, 0xD5, 0xD7, 0x89, 0xC2, 0xB7, 0x65, 0x44, 0x8C,
                 0x86, 0x35, 0xFB, 0x6C
             ]
         )
+    }
+    #[test]
+    fn long_ascii() {
+        let mut res = SHA256::new_default();
+        let val = &b"The quick brown fox jumps over the lazy dog.".to_vec();
+        for _ in 0..1000 {
+            res.update(val);
+        }
+        let hash = res.get_hash();
+        assert_eq!(
+            &get_hash_string(&hash),
+            "c264fca077807d391df72fadf39dd63be21f1823f65ca530c9637760eabfc18c"
+        );
+        let mut res = SHA256::new_default();
+        let val = &b"a".to_vec();
+        for _ in 0..999 {
+            res.update(val);
+        }
+        let hash = res.get_hash();
+        assert_eq!(
+            &get_hash_string(&hash),
+            "d9fe27f3d807a7c46467325f7189495e82b099ce2e14c5b16cc76697fa909f81"
+        )
+    }
+    #[test]
+    fn short_ascii() {
+        let mut res = SHA256::new_default();
+        let val = &b"a".to_vec();
+        res.update(val);
+        let hash = res.get_hash();
+        assert_eq!(
+            &get_hash_string(&hash),
+            "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"
+        );
     }
 }


### PR DESCRIPTION
Hi,
This is a draft of what I think our cryptography infrastructure should look like. We should at least try to have a trait for various cryptographic hashing function that we implement in the future. Also I tried to implement HMAC based on [RFC 2104](https://www.rfc-editor.org/rfc/rfc2104) using the proposed trait. I am looking for feedback on the Hashing trait and whether the most important functionality is there.

I really wanted to have a demo for HMAC using the already implemented `sha256` function, but after having a closer look, I realized this function has some implementation flaws ([here](https://github.com/TheAlgorithms/Rust/blob/83ad008c24d9d264039dabda2375800da0f38d5b/src/ciphers/sha256.rs#L122) for example) that slow it down considerably. As such I need more time and the feedback from the Hashing trait before I can test this HMAC implementation.