### PR TITLE
Optimize graph breadth_first_search

### DIFF
--- a/src/graph/breadth_first_search.rs
+++ b/src/graph/breadth_first_search.rs
@@ -34,8 +34,7 @@ pub fn breadth_first_search(graph: &Graph, root: Node, target: Node) -> Option<V
 
         // Check the neighboring nodes for any that we've not visited yet.
         for neighbor in currentnode.neighbors(graph) {
-            if !visited.contains(&neighbor) {
-                visited.insert(neighbor);
+            if visited.insert(neighbor) {
                 queue.push_back(neighbor);
             }
         }


### PR DESCRIPTION
On `insert` operation, If the set did have the value present, `false` is returned. So there is no need to use `contains` operation.