### PR TITLE
fix: Make xor output Vec<u8>

### DIFF
--- a/src/ciphers/xor.rs
+++ b/src/ciphers/xor.rs
@@ -1,5 +1,9 @@
-pub fn xor(text: &str, key: u8) -> String {
-    text.chars().map(|c| ((c as u8) ^ key) as char).collect()
+pub fn xor_bytes(text: &[u8], key: u8) -> Vec<u8> {
+    text.iter().map(|c| c ^ key).collect()
+}
+
+pub fn xor(text: &str, key: u8) -> Vec<u8> {
+    xor_bytes(text.as_bytes(), key)
 }
 
 #[cfg(test)]
@@ -10,13 +14,37 @@ mod tests {
     fn test_simple() {
         let test_string = "test string";
         let ciphered_text = xor(test_string, 32);
-        assert_eq!(test_string, xor(&ciphered_text, 32));
+        assert_eq!(test_string.as_bytes(), xor_bytes(&ciphered_text, 32));
     }
 
     #[test]
     fn test_every_alphabet_with_space() {
         let test_string = "The quick brown fox jumps over the lazy dog";
         let ciphered_text = xor(test_string, 64);
-        assert_eq!(test_string, xor(&ciphered_text, 64));
+        assert_eq!(test_string.as_bytes(), xor_bytes(&ciphered_text, 64));
+    }
+
+    #[test]
+    fn test_multi_byte() {
+        let test_string = "日本語";
+        let key = 42;
+        let ciphered_text = xor(test_string, key);
+        assert_eq!(test_string.as_bytes(), xor_bytes(&ciphered_text, key));
+    }
+
+    #[test]
+    fn test_zero_byte() {
+        let test_string = "The quick brown fox jumps over the lazy dog";
+        let key = ' ' as u8;
+        let ciphered_text = xor(test_string, key);
+        assert_eq!(test_string.as_bytes(), xor_bytes(&ciphered_text, key));
+    }
+
+    #[test]
+    fn test_invalid_byte() {
+        let test_string = "The quick brown fox jumps over the lazy dog";
+        let key = !0 as u8;
+        let ciphered_text = xor(test_string, key);
+        assert_eq!(test_string.as_bytes(), xor_bytes(&ciphered_text, key));
     }
 }


### PR DESCRIPTION
String is documented as utf8 encoded text.
This can contain multibytes. The cast of char to u8 is lossy.

test_multi_byte fails before the API change.
The other new tests also test common encoding issues.
The don't fail on the old code, but the intermediaries are invalid.


This could also be done with e.g. `Box<[u8]>`, but String is growable, so `Vec<u8>` should be fine.

This changes the API, but since the old one necessarily violates documented type properties, IMO it needs to be done.