### PR TITLE
Refactor coin change to be more idiomatic Rust code

### DIFF
--- a/src/dynamic_programming/coin_change.rs
+++ b/src/dynamic_programming/coin_change.rs
@@ -10,23 +10,26 @@
 ///     - time complexity: O(amount * coins.length),
 ///     - space complexity: O(amount),
 pub fn coin_change(coins: &[usize], amount: usize) -> Option<usize> {
-    let mut dp = vec![std::usize::MAX; amount + 1];
-    dp[0] = 0;
+    let mut dp = vec![None; amount + 1];
+    dp[0] = Some(0);
 
     // Assume dp[i] is the fewest number of coins making up amount i,
     // then for every coin in coins, dp[i] = min(dp[i - coin] + 1).
     for i in 0..=amount {
         for &coin in coins {
-            if i >= coin && dp[i - coin] != std::usize::MAX {
-                dp[i] = dp[i].min(dp[i - coin] + 1);
+            if i >= coin {
+                dp[i] = match dp[i - coin] {
+                    Some(prev_coins) => match dp[i] {
+                        Some(curr_coins) => Some(curr_coins.min(prev_coins + 1)),
+                        None => Some(prev_coins + 1),
+                    },
+                    None => dp[i],
+                };
             }
         }
     }
 
-    match dp[amount] {
-        std::usize::MAX => None,
-        _ => Some(dp[amount]),
-    }
+    dp[amount]
 }
 
 #[cfg(test)]

--- a/src/dynamic_programming/coin_change.rs
+++ b/src/dynamic_programming/coin_change.rs
@@ -16,9 +16,9 @@ pub fn coin_change(coins: &[usize], amount: usize) -> Option<usize> {
     // Assume dp[i] is the fewest number of coins making up amount i,
     // then for every coin in coins, dp[i] = min(dp[i - coin] + 1).
     for i in 0..=amount {
-        for j in 0..coins.len() {
-            if i >= coins[j] && dp[i - coins[j]] != std::usize::MAX {
-                dp[i] = dp[i].min(dp[i - coins[j]] + 1);
+        for &coin in coins {
+            if i >= coin && dp[i - coin] != std::usize::MAX {
+                dp[i] = dp[i].min(dp[i - coin] + 1);
             }
         }
     }


### PR DESCRIPTION
I've adapted the `coin_change`-solution to use `Option`s instead of treating the type's `MAX`-value as a sort of magic number.
The algorithm logic needed to be slightly refactored to work on `Option`s. To implement the solution with those, I had to decide between two paradigms to default to: `match`- or `map`-statements.

To my knowledge Rust doesn't have an explicit preference between the two, so I decided to submit both viable versions in separate commits:
- 6257ca1 for the `match`-version
- 3b6237b for the `map`-version

Before merging the PR, we should settle on the version that you prefer to adopt (if any :wink: ). The other could then be dropped or fixup-d, respectively.

I did run cargo's `test`, `fmt` and the `clippy`-command specified in the [guidelines](https://github.com/TheAlgorithms/Rust/blob/master/CONTRIBUTING.md) on both commits, so both should be good to merge otherwise.
Let me know if there's anything else I should consider or rework.