### PR TITLE
add ceil

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ These are for demonstration purposes only.
 
 - [x] [Amicable numbers below N](./src/math/amicable_numbers.rs)
 - [x] [Baby-Step Giant-Step Algorithm](./src/math/baby_step_giant_step.rs)
-- [x] [ceil](./src/math/ceil.rs)
+- [x] [Ceil](./src/math/ceil.rs)
 - [x] [Chinese Remainder Theorem](./src/math/chinese_remainder_theorem.rs)
 - [x] [Extended euclidean algorithm](./src/math/extended_euclidean_algorithm.rs)
 - [x] [Fast Inverse Square Root 'Quake' Algorithm](./src/math/square_root.rs)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ These are for demonstration purposes only.
 
 - [x] [Amicable numbers below N](./src/math/amicable_numbers.rs)
 - [x] [Baby-Step Giant-Step Algorithm](./src/math/baby_step_giant_step.rs)
+- [x] [ceil](./src/math/ceil.rs)
 - [x] [Chinese Remainder Theorem](./src/math/chinese_remainder_theorem.rs)
 - [x] [Extended euclidean algorithm](./src/math/extended_euclidean_algorithm.rs)
 - [x] [Fast Inverse Square Root 'Quake' Algorithm](./src/math/square_root.rs)

--- a/src/math/ceil.rs
+++ b/src/math/ceil.rs
@@ -1,0 +1,46 @@
+// In mathematics and computer science, the ceiling function maps x to the least integer greater than or equal to x
+// Source: https://en.wikipedia.org/wiki/Floor_and_ceiling_functions
+
+pub fn ceil(x: f64) -> f64 {
+  let x_round = x.round();
+  if (x_round * 10.0).round() < (x * 10.0).round() {
+    x_round + 1.0
+  } else {
+    x_round
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn positive_decimal() {
+    let num = 1.10;
+    assert_eq!(ceil(num), num.ceil());
+  }
+
+  #[test]
+  fn positive_integer() {
+    let num = 1.00;
+    assert_eq!(ceil(num), num.ceil());
+  }
+
+  #[test]
+  fn negative_decimal() {
+    let num = -1.10;
+    assert_eq!(ceil(num), num.ceil());
+  }
+
+  #[test]
+  fn negative_integer() {
+    let num = -1.00;
+    assert_eq!(ceil(num), num.ceil());
+  }
+
+    #[test]
+  fn zero() {
+    let num = 0.00;
+    assert_eq!(ceil(num), num.ceil());
+  }
+}

--- a/src/math/ceil.rs
+++ b/src/math/ceil.rs
@@ -2,45 +2,45 @@
 // Source: https://en.wikipedia.org/wiki/Floor_and_ceiling_functions
 
 pub fn ceil(x: f64) -> f64 {
-  let x_round = x.round();
-  if (x_round * 10.0).round() < (x * 10.0).round() {
-    x_round + 1.0
-  } else {
-    x_round
-  }
+    let x_round = x.round();
+    if (x_round * 10.0).round() < (x * 10.0).round() {
+        x_round + 1.0
+    } else {
+        x_round
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-
-  #[test]
-  fn positive_decimal() {
-    let num = 1.10;
-    assert_eq!(ceil(num), num.ceil());
-  }
-
-  #[test]
-  fn positive_integer() {
-    let num = 1.00;
-    assert_eq!(ceil(num), num.ceil());
-  }
-
-  #[test]
-  fn negative_decimal() {
-    let num = -1.10;
-    assert_eq!(ceil(num), num.ceil());
-  }
-
-  #[test]
-  fn negative_integer() {
-    let num = -1.00;
-    assert_eq!(ceil(num), num.ceil());
-  }
+    use super::*;
 
     #[test]
-  fn zero() {
-    let num = 0.00;
-    assert_eq!(ceil(num), num.ceil());
-  }
+    fn positive_decimal() {
+        let num = 1.10;
+        assert_eq!(ceil(num), num.ceil());
+    }
+
+    #[test]
+    fn positive_integer() {
+        let num = 1.00;
+        assert_eq!(ceil(num), num.ceil());
+    }
+
+    #[test]
+    fn negative_decimal() {
+        let num = -1.10;
+        assert_eq!(ceil(num), num.ceil());
+    }
+
+    #[test]
+    fn negative_integer() {
+        let num = -1.00;
+        assert_eq!(ceil(num), num.ceil());
+    }
+
+    #[test]
+    fn zero() {
+        let num = 0.00;
+        assert_eq!(ceil(num), num.ceil());
+    }
 }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,6 +1,7 @@
 mod amicable_numbers;
 mod armstrong_number;
 mod baby_step_giant_step;
+mod ceil;
 mod chinese_remainder_theorem;
 mod collatz_sequence;
 mod doomsday;
@@ -37,6 +38,7 @@ mod zellers_congruence_algorithm;
 pub use self::amicable_numbers::amicable_pairs_under_n;
 pub use self::armstrong_number::is_armstrong_number;
 pub use self::baby_step_giant_step::baby_step_giant_step;
+pub use self::ceil::ceil;
 pub use self::chinese_remainder_theorem::chinese_remainder_theorem;
 pub use self::collatz_sequence::sequence;
 pub use self::doomsday::get_week_day;


### PR DESCRIPTION
- ceil() algorithm implement

I found [the Python repository](https://github.com/TheAlgorithms/Python/blob/32ff33648e0d1f93398db34fd271aa6606abc3a4/maths/ceil.py) has ceil algorithm, but this repository doesn't have it.

@siriak Please review