### PR TITLE
fix math error in case of `lo == 0` in first iteration

### DIFF
--- a/src/sorting/quick_sort.rs
+++ b/src/sorting/quick_sort.rs
@@ -2,7 +2,8 @@ use std::cmp::PartialOrd;
 
 pub fn partition<T: PartialOrd>(arr: &mut [T], lo: isize, hi: isize) -> isize {
     let pivot = hi as usize;
-    let mut i = lo - 1;
+    let mut i = lo;
+    i = i.saturating_sub(1);
     let mut j = hi;
 
     loop {


### PR DESCRIPTION
In case of call 
```
_quick_sort(arr, 0, (len - 1) as isize);
```
we are have lo variable equals to 0, which is going to bad math operation when partition calls with this one