### PR TITLE
Fix Ciphers README

### DIFF
--- a/src/ciphers/README.md
+++ b/src/ciphers/README.md
@@ -34,7 +34,7 @@ Many people have tried to implement encryption schemes that are essentially Vige
 SHA-2 (Secure Hash Algorithm 2) is a set of cryptographic hash functions designed by the United States National Security Agency (NSA) and first published in 2001. They are built using the Merkle–Damgård structure, from a one-way compression function itself built using the Davies–Meyer structure from a (classified) specialized block cipher. 
 ###### Source: [Wikipedia](https://en.wikipedia.org/wiki/SHA-2)
 
-### Transposition _(Not implemented yet)_
+### [Transposition](./transposition.rs)
 In cryptography, a **transposition cipher** is a method of encryption by which the positions held by units of plaintext (which are commonly characters or groups of characters) are shifted according to a regular system, so that the ciphertext constitutes a permutation of the plaintext. That is, the order of the units is changed (the plaintext is reordered).<br> 
 Mathematically a bijective function is used on the characters' positions to encrypt and an inverse function to decrypt.
 ###### Source: [Wikipedia](https://en.wikipedia.org/wiki/Transposition_cipher)


### PR DESCRIPTION
Just find that _Transposition_ in `ciphers` section was implemented but not linked in README. 