### PR TITLE
fix: clippy::unit_cmp warning

### DIFF
--- a/src/string/autocomplete_using_trie.rs
+++ b/src/string/autocomplete_using_trie.rs
@@ -111,14 +111,19 @@ mod tests {
         let prefix = "app".to_owned();
         let mut auto_completed_words = auto_complete.find_words(prefix);
 
-        assert_eq!(auto_completed_words.sort(), vec!["apple".to_owned()].sort());
+        let mut apple = vec!["apple".to_owned()];
+        apple.sort();
+
+        auto_completed_words.sort();
+        assert_eq!(auto_completed_words, apple);
 
         let prefix = "or".to_owned();
         let mut auto_completed_words = auto_complete.find_words(prefix);
 
-        assert_eq!(
-            auto_completed_words.sort(),
-            vec!["orange".to_owned(), "oregano".to_owned()].sort()
-        );
+        let mut prefix_or = vec!["orange".to_owned(), "oregano".to_owned()];
+        prefix_or.sort();
+
+        auto_completed_words.sort();
+        assert_eq!(auto_completed_words, prefix_or);
     }
 }


### PR DESCRIPTION
## Description

fix: clippy::unit_cmp warning: Since the sort() method of 'vec' does not have a return value, calling it directly from an assert statement will always evaluate to true, triggering a "unit_cmp" error reported by Clippy.

## Type of change

- [√] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [√] I ran bellow commands using the latest version of **rust nightly**.
- [√] I ran `cargo clippy --all -- -D warning` just before my last commit and fixed any issue that was found.
- [√] I ran `cargo fmt` just before my last commit.
- [√] I ran `cargo test` just before my last commit and all tests passed.
- [√] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
