### PR TITLE
Documentation formatting

### DIFF
--- a/src/ciphers/chacha.rs
+++ b/src/ciphers/chacha.rs
@@ -1,10 +1,3 @@
-/*
- * ChaCha20 implementation based on RFC8439
- * ChaCha20 is a stream cipher developed independently by Daniel J. Bernstein.
- * To use it, the `chacha20` function should be called with appropriate
- * parameters and the output of the function should be XORed with plain text.
- */
-
 macro_rules! quarter_round {
     ($a:expr,$b:expr,$c:expr,$d:expr) => {
         $a = $a.wrapping_add($b);
@@ -22,66 +15,74 @@ macro_rules! quarter_round {
 // "expand 32-byte k", written in little-endian order
 pub const C: [u32; 4] = [0x61707865, 0x3320646e, 0x79622d32, 0x6b206574];
 
-/**
- * `chacha20` function takes as input an array of 16 32-bit integers (512 bits)
- * of which 128 bits is the constant 'expand 32-byte k', 256 bits is the key,
- * and 128 bits are nonce and counter. According to RFC8439, the nonce should
- * be 96 bits long, which leaves 32 bits for the counter. Given that the block
- * length is 512 bits, this leaves enough counter values to encrypt 256GB of
- * data.
- *
- * The 16 input numbers can be thought of as the elements of a 4x4 matrix like
- * the one bellow, on which we do the main operations of the cipher.
- *
- * +----+----+----+----+
- * | 00 | 01 | 02 | 03 |
- * +----+----+----+----+
- * | 04 | 05 | 06 | 07 |
- * +----+----+----+----+
- * | 08 | 09 | 10 | 11 |
- * +----+----+----+----+
- * | 12 | 13 | 14 | 15 |
- * +----+----+----+----+
- *
- * As per the diagram bellow, input[0, 1, 2, 3] are the constants mentioned
- * above, input[4..=11] is filled with the key, and input[6..=9] should be
- * filled with nonce and counter values. The output of the function is stored
- * in `output` variable and can be XORed with the plain text to produce the
- * cipher text.
- *
- * +------+------+------+------+
- * |      |      |      |      |
- * | C[0] | C[1] | C[2] | C[3] |
- * |      |      |      |      |
- * +------+------+------+------+
- * |      |      |      |      |
- * | key0 | key1 | key2 | key3 |
- * |      |      |      |      |
- * +------+------+------+------+
- * |      |      |      |      |
- * | key4 | key5 | key6 | key7 |
- * |      |      |      |      |
- * +------+------+------+------+
- * |      |      |      |      |
- * | ctr0 | no.0 | no.1 | no.2 |
- * |      |      |      |      |
- * +------+------+------+------+
- *
- * Note that the constants, the key, and the nonce should be written in
- * little-endian order, meaning that for example if the key is 01:02:03:04
- * (in hex), it corresponds to the integer 0x04030201. It is important to
- * know that the hex value of the counter is meaningless, and only its integer
- * value matters, and it should start with (for example) 0x00000000, and then
- * 0x00000001 and so on until 0xffffffff. Keep in mind that as soon as we get
- * from bytes to words, we stop caring about their representation in memory,
- * and we only need the math to be correct.
- *
- * The output of the function can be used without any change, as long as the
- * plain text has the same endianness. For example if the plain text is
- * "hello world", and the first word of the output is 0x01020304, then the
- * first byte of plain text ('h') should be XORed with the least-significant
- * byte of 0x01020304, which is 0x04.
-*/
+/// ChaCha20 implementation based on RFC8439
+///
+/// ChaCha20 is a stream cipher developed independently by Daniel J. Bernstein.\
+/// To use it, the `chacha20` function should be called with appropriate
+/// parameters and the output of the function should be XORed with plain text.
+///
+/// `chacha20` function takes as input an array of 16 32-bit integers (512 bits)
+/// of which 128 bits is the constant 'expand 32-byte k', 256 bits is the key,
+/// and 128 bits are nonce and counter. According to RFC8439, the nonce should
+/// be 96 bits long, which leaves 32 bits for the counter. Given that the block
+/// length is 512 bits, this leaves enough counter values to encrypt 256GB of
+/// data.
+///
+/// The 16 input numbers can be thought of as the elements of a 4x4 matrix like
+/// the one bellow, on which we do the main operations of the cipher.
+///
+/// ```text
+/// +----+----+----+----+
+/// | 00 | 01 | 02 | 03 |
+/// +----+----+----+----+
+/// | 04 | 05 | 06 | 07 |
+/// +----+----+----+----+
+/// | 08 | 09 | 10 | 11 |
+/// +----+----+----+----+
+/// | 12 | 13 | 14 | 15 |
+/// +----+----+----+----+
+/// ```
+///
+/// As per the diagram bellow, `input[0, 1, 2, 3]` are the constants mentioned
+/// above, `input[4..=11]` is filled with the key, and `input[6..=9]` should be
+/// filled with nonce and counter values. The output of the function is stored
+/// in `output` variable and can be XORed with the plain text to produce the
+/// cipher text.
+///
+/// ```text
+/// +------+------+------+------+
+/// |      |      |      |      |
+/// | C[0] | C[1] | C[2] | C[3] |
+/// |      |      |      |      |
+/// +------+------+------+------+
+/// |      |      |      |      |
+/// | key0 | key1 | key2 | key3 |
+/// |      |      |      |      |
+/// +------+------+------+------+
+/// |      |      |      |      |
+/// | key4 | key5 | key6 | key7 |
+/// |      |      |      |      |
+/// +------+------+------+------+
+/// |      |      |      |      |
+/// | ctr0 | no.0 | no.1 | no.2 |
+/// |      |      |      |      |
+/// +------+------+------+------+
+/// ```
+///
+/// Note that the constants, the key, and the nonce should be written in
+/// little-endian order, meaning that for example if the key is 01:02:03:04
+/// (in hex), it corresponds to the integer `0x04030201`. It is important to
+/// know that the hex value of the counter is meaningless, and only its integer
+/// value matters, and it should start with (for example) `0x00000000`, and then
+/// `0x00000001` and so on until `0xffffffff`. Keep in mind that as soon as we get
+/// from bytes to words, we stop caring about their representation in memory,
+/// and we only need the math to be correct.
+///
+/// The output of the function can be used without any change, as long as the
+/// plain text has the same endianness. For example if the plain text is
+/// "hello world", and the first word of the output is `0x01020304`, then the
+/// first byte of plain text ('h') should be XORed with the least-significant
+/// byte of `0x01020304`, which is `0x04`.
 pub fn chacha20(input: &[u32; 16], output: &mut [u32; 16]) {
     output.copy_from_slice(&input[..]);
     for _ in 0..10 {

--- a/src/ciphers/salsa.rs
+++ b/src/ciphers/salsa.rs
@@ -1,10 +1,3 @@
-/*
- * Salsa20 implementation based on https://en.wikipedia.org/wiki/Salsa20
- * Salsa20 is a stream cipher developed by Daniel J. Bernstein. To use it, the
- * `salsa20` function should be called with appropriate parameters and the
- * output of the function should be XORed with plain text.
- */
-
 macro_rules! quarter_round {
     ($v1:expr,$v2:expr,$v3:expr,$v4:expr) => {
         $v2 ^= ($v1.wrapping_add($v4).rotate_left(7));
@@ -14,50 +7,57 @@ macro_rules! quarter_round {
     };
 }
 
-/**
- * `salsa20` function takes as input an array of 16 32-bit integers (512 bits)
- * of which 128 bits is the constant 'expand 32-byte k', 256 bits is the key,
- * and 128 bits are nonce and counter. It is up to the user to determine how
- * many bits each of nonce and counter take, but a default of 64 bits each
- * seems to be a sane choice.
- *
- * The 16 input numbers can be thought of as the elements of a 4x4 matrix like
- * the one bellow, on which we do the main operations of the cipher.
- *
- * +----+----+----+----+
- * | 00 | 01 | 02 | 03 |
- * +----+----+----+----+
- * | 04 | 05 | 06 | 07 |
- * +----+----+----+----+
- * | 08 | 09 | 10 | 11 |
- * +----+----+----+----+
- * | 12 | 13 | 14 | 15 |
- * +----+----+----+----+
- *
- * As per the diagram bellow, input[0, 5, 10, 15] are the constants mentioned
- * above, input[1, 2, 3, 4, 11, 12, 13, 14] is filled with the key, and
- * input[6, 7, 8, 9] should be filled with nonce and counter values. The output
- * of the function is stored in `output` variable and can be XORed with the
- * plain text to produce the cipher text.
- *
- * +------+------+------+------+
- * |      |      |      |      |
- * | C[0] | key1 | key2 | key3 |
- * |      |      |      |      |
- * +------+------+------+------+
- * |      |      |      |      |
- * | key4 | C[1] | no1  | no2  |
- * |      |      |      |      |
- * +------+------+------+------+
- * |      |      |      |      |
- * | ctr1 | ctr2 | C[2] | key5 |
- * |      |      |      |      |
- * +------+------+------+------+
- * |      |      |      |      |
- * | key6 | key7 | key8 | C[3] |
- * |      |      |      |      |
- * +------+------+------+------+
-*/
+/// This is a `Salsa20` implementation based on <https://en.wikipedia.org/wiki/Salsa20>\
+/// `Salsa20` is a stream cipher developed by Daniel J. Bernstein.\
+/// To use it, the `salsa20` function should be called with appropriate parameters and the
+/// output of the function should be XORed with plain text.
+///
+/// `salsa20` function takes as input an array of 16 32-bit integers (512 bits)
+/// of which 128 bits is the constant 'expand 32-byte k', 256 bits is the key,
+/// and 128 bits are nonce and counter. It is up to the user to determine how
+/// many bits each of nonce and counter take, but a default of 64 bits each
+/// seems to be a sane choice.
+///
+/// The 16 input numbers can be thought of as the elements of a 4x4 matrix like
+/// the one bellow, on which we do the main operations of the cipher.
+///
+/// ```text
+/// +----+----+----+----+
+/// | 00 | 01 | 02 | 03 |
+/// +----+----+----+----+
+/// | 04 | 05 | 06 | 07 |
+/// +----+----+----+----+
+/// | 08 | 09 | 10 | 11 |
+/// +----+----+----+----+
+/// | 12 | 13 | 14 | 15 |
+/// +----+----+----+----+
+/// ```
+///
+/// As per the diagram bellow, `input[0, 5, 10, 15]` are the constants mentioned
+/// above, `input[1, 2, 3, 4, 11, 12, 13, 14]` is filled with the key, and
+/// `input[6, 7, 8, 9]` should be filled with nonce and counter values. The output
+/// of the function is stored in `output` variable and can be XORed with the
+/// plain text to produce the cipher text.
+///
+/// ```text
+/// +------+------+------+------+
+/// |      |      |      |      |
+/// | C[0] | key1 | key2 | key3 |
+/// |      |      |      |      |
+/// +------+------+------+------+
+/// |      |      |      |      |
+/// | key4 | C[1] | no1  | no2  |
+/// |      |      |      |      |
+/// +------+------+------+------+
+/// |      |      |      |      |
+/// | ctr1 | ctr2 | C[2] | key5 |
+/// |      |      |      |      |
+/// +------+------+------+------+
+/// |      |      |      |      |
+/// | key6 | key7 | key8 | C[3] |
+/// |      |      |      |      |
+/// +------+------+------+------+
+/// ```
 pub fn salsa20(input: &[u32; 16], output: &mut [u32; 16]) {
     output.copy_from_slice(&input[..]);
     for _ in 0..10 {

--- a/src/data_structures/fenwick_tree.rs
+++ b/src/data_structures/fenwick_tree.rs
@@ -1,9 +1,10 @@
 use std::ops::{Add, AddAssign};
 
 /// Fenwick Tree / Binary Indexed Tree
-/// Consider we have an array arr[0 . . . n-1]. We would like to
+///
+/// Consider we have an array `arr[0...n-1]`. We would like to:
 /// 1. Compute the sum of the first i elements.
-/// 2. Modify the value of a specified element of the array arr[i] = x where 0 <= i <= n-1.Fenwick tree
+/// 2. Modify the value of a specified element of the array `arr[i] = x`, where `0 <= i <= n-1`.
 pub struct FenwickTree<T: Add + AddAssign + Copy + Default> {
     data: Vec<T>,
 }

--- a/src/data_structures/stack_using_singly_linked_list.rs
+++ b/src/data_structures/stack_using_singly_linked_list.rs
@@ -1,4 +1,4 @@
-// the public struct can hide the implementation detail
+// The public struct can hide the implementation detail
 pub struct Stack<T> {
     head: Link<T>,
 }
@@ -21,8 +21,8 @@ impl<T> Stack<T> {
         } // we need to return the variant, so there without the ;
     }
 
-    // As we know the primary forms that self can take: self, &mut self and &self, push will change the linked list
-    // so we need &mut
+    // Here are the primary forms that self can take are: self, &mut self and &self.
+    // Since push will modify the linked list, we need a mutable reference `&mut`.
     // The push method which the signature's first parameter is self
     pub fn push(&mut self, elem: T) {
         let new_node = Box::new(Node {
@@ -32,17 +32,17 @@ impl<T> Stack<T> {
         // don't forget replace the head with new node for stack
         self.head = Some(new_node);
     }
+
+    /// The pop function removes the head and returns its value.
     ///
-    /// In pop function, we trying to:
-    /// * check if the list is empty, so we use enum Option<T>, it can either be Some(T) or None
-    ///   * if it's empty, return None
-    ///   * if it's not empty
-    ///     * remove the head of the list
-    ///     * remove its elem
-    ///     * replace the list's head with its next
-    ///     * return Some(elem), as the situation if need
-    ///
-    /// so, we need to remove the head, and return the value of the head
+    /// To do so, we'll need to match the `head` of the list, which is of enum type `Option<T>`.\
+    /// It has two variants: `Some(T)` and `None`.
+    /// * `None` - the list is empty:
+    ///   * return an enum `Result` of variant `Err()`, as there is nothing to pop.
+    /// * `Some(node)` - the list is not empty:
+    ///   * remove the head of the list,
+    ///   * relink the list's head `head` to its following node `next`,
+    ///   * return `Ok(elem)`.
     pub fn pop(&mut self) -> Result<T, &str> {
         match self.head.take() {
             None => Err("Stack is empty"),
@@ -54,7 +54,7 @@ impl<T> Stack<T> {
     }
 
     pub fn is_empty(&self) -> bool {
-        // Returns true if the option is a [None] value.
+        // Returns true if head is of variant `None`.
         self.head.is_none()
     }
 
@@ -95,16 +95,17 @@ impl<T> Default for Stack<T> {
     }
 }
 
-/// The drop method of singly linked list. There's a question that do we need to worry about cleaning up our list?
-/// As we all know the ownership and borrow mechanism, so we know the type will clean automatically after it goes out the scope,
-/// this implement by the Rust compiler automatically did which mean add trait `drop` for the automatically.
+/// The drop method of singly linked list.
 ///
-/// So, the complier will implements Drop for `List->Link->Box<Node> ->Node` automatically and tail recursive to clean the elements
-/// one by one. And we know the recursive will stop at Box<Node>
-/// https://rust-unofficial.github.io/too-many-lists/first-drop.html
+/// Here's a question: *Do we need to worry about cleaning up our list?*\
+/// With the help of the ownership mechanism, the type `List` will be cleaned up automatically (dropped) after it goes out of scope.\
+/// The Rust Compiler does so automacally. In other words, the `Drop` trait is implemented automatically.\
 ///
-/// As we know we can't drop the contents of the Box after deallocating, so we need to manually write the iterative drop
-
+/// The `Drop` trait is implemented for our type `List` with the following order: `List->Link->Box<Node>->Node`.\
+/// The `.drop()` method is tail recursive and will clean the element one by one, this recursion will stop at `Box<Node>`\
+/// <https://rust-unofficial.github.io/too-many-lists/first-drop.html>
+///
+/// We wouldn't be able to drop the contents contained by the box after deallocating, so we need to manually write the iterative drop.
 impl<T> Drop for Stack<T> {
     fn drop(&mut self) {
         let mut cur_link = self.head.take();
@@ -117,7 +118,7 @@ impl<T> Drop for Stack<T> {
     }
 }
 
-/// Rust has nothing like a yield statement, and there's actually 3 different kinds of iterator should to implement
+// Rust has nothing like a yield statement, and there are actually 3 different iterator traits to be implemented
 
 // Collections are iterated in Rust using the Iterator trait, we define a struct implement Iterator
 pub struct IntoIter<T>(Stack<T>);

--- a/src/dynamic_programming/coin_change.rs
+++ b/src/dynamic_programming/coin_change.rs
@@ -3,12 +3,12 @@
 /// coin_change(coins, amount) returns the fewest number of coins that need to make up that amount.
 /// If that amount of money cannot be made up by any combination of the coins, return `None`.
 ///
-/// Arguments:
-///     * `coins` - coins of different denominations
-///     * `amount` - a total amount of money be made up.
-/// Complexity
-///     - time complexity: O(amount * coins.length),
-///     - space complexity: O(amount),
+/// # Arguments:
+///   * `coins` - coins of different denominations
+///   * `amount` - a total amount of money be made up.
+/// # Complexity
+///   - time complexity: O(amount * coins.length),
+///   - space complexity: O(amount),
 pub fn coin_change(coins: &[usize], amount: usize) -> Option<usize> {
     let mut dp = vec![None; amount + 1];
     dp[0] = Some(0);

--- a/src/dynamic_programming/knapsack.rs
+++ b/src/dynamic_programming/knapsack.rs
@@ -3,10 +3,10 @@ use std::cmp::max;
 
 /// knapsack_table(w, weights, values) returns the knapsack table (`n`, `m`) with maximum values, where `n` is number of items
 ///
-/// Arguments:
-///     * `w` - knapsack capacity
-///     * `weights` - set of weights for each item
-///     * `values` - set of values for each item
+/// # Arguments:
+///   * `w` - knapsack capacity
+///   * `weights` - set of weights for each item
+///   * `values` - set of values for each item
 fn knapsack_table(w: &usize, weights: &[usize], values: &[usize]) -> Vec<Vec<usize>> {
     // Initialize `n` - number of items
     let n: usize = weights.len();
@@ -36,11 +36,11 @@ fn knapsack_table(w: &usize, weights: &[usize], values: &[usize]) -> Vec<Vec<usi
 
 /// knapsack_items(weights, m, i, j) returns the indices of the items of the optimal knapsack (from 1 to `n`)
 ///
-/// Arguments:
-///     * `weights` - set of weights for each item
-///     * `m` - knapsack table with maximum values
-///     * `i` - include items 1 through `i` in knapsack (for the initial value, use `n`)
-///     * `j` - maximum weight of the knapsack
+/// # Arguments:
+///   * `weights` - set of weights for each item
+///   * `m` - knapsack table with maximum values
+///   * `i` - include items 1 through `i` in knapsack (for the initial value, use `n`)
+///   * `j` - maximum weight of the knapsack
 fn knapsack_items(weights: &[usize], m: &[Vec<usize>], i: usize, j: usize) -> Vec<usize> {
     if i == 0 {
         return vec![];
@@ -54,19 +54,19 @@ fn knapsack_items(weights: &[usize], m: &[Vec<usize>], i: usize, j: usize) -> Ve
     }
 }
 
-/// knapsack(w, weights, values) returns the tuple where first value is `optimal profit`,
-/// second value is `knapsack optimal weight` and the last value is `indices of items`, that we got (from 1 to `n`)
+/// knapsack(w, weights, values) returns the tuple where first value is "optimal profit",
+/// second value is "knapsack optimal weight" and the last value is "indices of items", that we got (from 1 to `n`)
 ///
-/// Arguments:
-///     * `w` - knapsack capacity
-///     * `weights` - set of weights for each item
-///     * `values` - set of values for each item
+/// # Arguments:
+///   * `w` - knapsack capacity
+///   * `weights` - set of weights for each item
+///   * `values` - set of values for each item
 ///
-/// Complexity
-///     - time complexity: O(nw),
-///     - space complexity: O(nw),
+/// # Complexity
+///   - time complexity: O(nw),
+///   - space complexity: O(nw),
 ///
-/// where `n` and `w` are `number of items` and `knapsack capacity`
+/// where `n` and `w` are "number of items" and "knapsack capacity"
 pub fn knapsack(w: usize, weights: Vec<usize>, values: Vec<usize>) -> (usize, usize, Vec<usize>) {
     // Checks if the number of items in the list of weights is the same as the number of items in the list of values
     assert_eq!(weights.len(), values.len(), "Number of items in the list of weights doesn't match the number of items in the list of values!");

--- a/src/dynamic_programming/maximal_square.rs
+++ b/src/dynamic_programming/maximal_square.rs
@@ -10,7 +10,7 @@ use std::cmp::min;
 ///   * `matrix` - an array of integer array
 ///
 /// # Complexity
-///   - time complexity: O(n<sup>2</sup>),
+///   - time complexity: O(n^2),
 ///   - space complexity: O(n),
 pub fn maximal_square(matrix: &mut [Vec<i32>]) -> i32 {
     if matrix.is_empty() {

--- a/src/dynamic_programming/maximal_square.rs
+++ b/src/dynamic_programming/maximal_square.rs
@@ -2,14 +2,16 @@ use std::cmp::max;
 use std::cmp::min;
 
 /// Maximal Square
-/// Given an m x n binary matrix filled with 0's and 1's, find the largest square containing only 1's and return its area.
-/// https://leetcode.com/problems/maximal-square/
 ///
-/// Arguments:
-///     * `matrix` - an array of integer array
-/// Complexity
-///     - time complexity: O(n^2),
-///     - space complexity: O(n),
+/// Given an `m` * `n` binary matrix filled with 0's and 1's, find the largest square containing only 1's and return its area.\
+/// <https://leetcode.com/problems/maximal-square/>
+///
+/// # Arguments:
+///   * `matrix` - an array of integer array
+///
+/// # Complexity
+///   - time complexity: O(n<sup>2</sup>),
+///   - space complexity: O(n),
 pub fn maximal_square(matrix: &mut [Vec<i32>]) -> i32 {
     if matrix.is_empty() {
         return 0;

--- a/src/general/permutations/steinhaus_johnson_trotter.rs
+++ b/src/general/permutations/steinhaus_johnson_trotter.rs
@@ -1,4 +1,4 @@
-/// https://en.wikipedia.org/wiki/Steinhaus%E2%80%93Johnson%E2%80%93Trotter_algorithm
+/// <https://en.wikipedia.org/wiki/Steinhaus%E2%80%93Johnson%E2%80%93Trotter_algorithm>
 pub fn steinhaus_johnson_trotter_permute<T: Clone>(array: &[T]) -> Vec<Vec<T>> {
     let len = array.len();
     let mut array = array.to_owned();

--- a/src/graph/centroid_decomposition.rs
+++ b/src/graph/centroid_decomposition.rs
@@ -1,24 +1,22 @@
-/*
-Centroid Decomposition for a tree.
-
-Given a tree, it can be recursively decomposed into centroids. Then the
-parent of a centroid `c` is the previous centroid that splitted its connected
-component into two or more components. It can be shown that in such
-decomposition, for each path `p` with starting and ending vertices `u`, `v`,
-the lowest common ancestor of `u` and `v` in centroid tree is a vertex of `p`.
-
-The input tree should have its vertices numbered from 1 to n, and
-`graph_enumeration.rs` may help to convert other representations.
- */
-
 type Adj = [Vec<usize>];
 
 const IN_DECOMPOSITION: u64 = 1 << 63;
+
+/// Centroid Decomposition for a tree.
+///
+/// Given a tree, it can be recursively decomposed into centroids. Then the
+/// parent of a centroid `c` is the previous centroid that splitted its connected
+/// component into two or more components. It can be shown that in such
+/// decomposition, for each path `p` with starting and ending vertices `u`, `v`,
+/// the lowest common ancestor of `u` and `v` in centroid tree is a vertex of `p`.
+///
+/// The input tree should have its vertices numbered from 1 to n, and
+/// `graph_enumeration.rs` may help to convert other representations.
 pub struct CentroidDecomposition {
     /// The root of the centroid tree, should _not_ be set by the user
     pub root: usize,
-    /// The result. decomposition[`v`] is the parent of `v` in centroid tree.
-    /// decomposition[`root`] is 0
+    /// The result. `decomposition[v]` is the parent of `v` in centroid tree.
+    /// `decomposition[root]` is 0
     pub decomposition: Vec<usize>,
     /// Used internally to save the big_child of a vertex, and whether it has
     /// been added to the centroid tree.

--- a/src/graph/floyd_warshall.rs
+++ b/src/graph/floyd_warshall.rs
@@ -4,15 +4,15 @@ use std::ops::Add;
 
 type Graph<V, E> = BTreeMap<V, BTreeMap<V, E>>;
 
-/// Performs the Floyd-Warshall algorithm on the input graph
-/// The graph is a weighted, directed graph with no negative cycles
+/// Performs the Floyd-Warshall algorithm on the input graph.\
+/// The graph is a weighted, directed graph with no negative cycles.
 ///
-/// Returns a map storing the distance from each node to all the others
-/// I.e. For each vertex u, map[u][v] == Some(distance) means
+/// Returns a map storing the distance from each node to all the others.\
+/// i.e. For each vertex `u`, `map[u][v] == Some(distance)` means
 /// distance is the sum of the weights of the edges on the shortest path
-/// from u to v
+/// from `u` to `v`.
 ///
-/// For a key v, if map[v].len() == 0, then v cannot reach any other vertex, but is in the graph
+/// For a key `v`, if `map[v].len() == 0`, then `v` cannot reach any other vertex, but is in the graph
 /// (island node, or sink in the case of a directed graph)
 pub fn floyd_warshall<V: Ord + Copy, E: Ord + Copy + Add<Output = E> + num_traits::Zero>(
     graph: &Graph<V, E>,

--- a/src/graph/two_satisfiability.rs
+++ b/src/graph/two_satisfiability.rs
@@ -12,11 +12,9 @@ fn variable(var: i64) -> usize {
     }
 }
 
-/// Returns an assignment that satisfies all the constraints, or a variable
-/// that makes such an assignment impossible. Variables should be numbered
-/// from 1 to n, and a negative number -m corresponds to the negated variable
-/// m. For more information about this problem, please visit:
-/// https://en.wikipedia.org/wiki/2-satisfiability
+/// Returns an assignment that satisfies all the constraints, or a variable that makes such an assignment impossible.\
+/// Variables should be numbered from 1 to `n`, and a negative number `-m` corresponds to the negated variable `m`.\
+/// For more information about this problem, please visit: <https://en.wikipedia.org/wiki/2-satisfiability>
 pub fn solve_two_satisfiability(
     expression: &[Condition],
     num_variables: usize,

--- a/src/math/abs.rs
+++ b/src/math/abs.rs
@@ -1,6 +1,7 @@
-/// This function returns the absolute value of a number.
-/// The absolute value of a number is the non-negative value of the number, regardless of its sign
-/// Wikipedia: https://en.wikipedia.org/wiki/Absolute_value
+/// This function returns the absolute value of a number.\
+/// The absolute value of a number is the non-negative value of the number, regardless of its sign.\
+///
+/// Wikipedia: <https://en.wikipedia.org/wiki/Absolute_value>
 pub fn abs(num: f64) -> f64 {
     if num < 0.0 {
         return -num;

--- a/src/math/aliquot_sum.rs
+++ b/src/math/aliquot_sum.rs
@@ -1,8 +1,10 @@
-/// Aliquot sum of a number is defined as the sum of the proper divisors of
-/// a number, i.e. all the divisors of a number apart from the number itself
-/// For example: The aliquot sum of 6 is (1 + 2 + 3) = 6, and that of 15 is
-/// (1 + 3 + 5) = 9
-/// Wikipedia article on Aliquot Sum: https://en.wikipedia.org/wiki/Aliquot_sum
+/// Aliquot sum of a number is defined as the sum of the proper divisors of a number.\
+/// i.e. all the divisors of a number apart from the number itself.
+///
+/// ## Example:
+/// The aliquot sum of 6 is (1 + 2 + 3) = 6, and that of 15 is (1 + 3 + 5) = 9
+///
+/// Wikipedia article on Aliquot Sum: <https://en.wikipedia.org/wiki/Aliquot_sum>
 
 pub fn aliquot_sum(number: u64) -> u64 {
     if number == 1 || number == 0 {

--- a/src/math/pascal_triangle.rs
+++ b/src/math/pascal_triangle.rs
@@ -1,13 +1,14 @@
-/// ## Paslcal's triangle problem
-
-/// pascal_triangle(num_rows) returns the first num_rows of Pascal's triangle.
-/// About Pascal's triangle: https://en.wikipedia.org/wiki/Pascal%27s_triangle
+/// ## Pascal's triangle problem
 ///
-/// Arguments:
-///     * `num_rows` - number of rows of triangle
-/// Complexity
-///     - time complexity: O(n^2),
-///     - space complexity: O(n^2),
+/// pascal_triangle(num_rows) returns the first num_rows of Pascal's triangle.\
+/// About Pascal's triangle: <https://en.wikipedia.org/wiki/Pascal%27s_triangle>
+///
+/// # Arguments:
+///   * `num_rows`: number of rows of triangle
+///
+/// # Complexity
+///   - time complexity: O(n<sup>2</sup>),
+///   - space complexity: O(n<sup>2</sup>),
 pub fn pascal_triangle(num_rows: i32) -> Vec<Vec<i32>> {
     let mut ans: Vec<Vec<i32>> = vec![];
 

--- a/src/math/pascal_triangle.rs
+++ b/src/math/pascal_triangle.rs
@@ -7,8 +7,8 @@
 ///   * `num_rows`: number of rows of triangle
 ///
 /// # Complexity
-///   - time complexity: O(n<sup>2</sup>),
-///   - space complexity: O(n<sup>2</sup>),
+///   - time complexity: O(n^2),
+///   - space complexity: O(n^2),
 pub fn pascal_triangle(num_rows: i32) -> Vec<Vec<i32>> {
     let mut ans: Vec<Vec<i32>> = vec![];
 

--- a/src/string/levenshtein_distance.rs
+++ b/src/string/levenshtein_distance.rs
@@ -1,30 +1,29 @@
 use std::cmp::min;
 
-/// The Levenshtein distance (or edit distance) between 2 strings
-/// This edit distance is defined as being 1 point per insertion,
-/// substitution, or deletion which must be made to make the strings equal.
+/// The Levenshtein distance (or edit distance) between 2 strings.\
+/// This edit distance is defined as being 1 point per insertion, substitution, or deletion which must be made to make the strings equal.
+/// This function iterates over the bytes in the string, so it may not behave entirely as expected for non-ASCII strings.
 ///
-/// This function iterates over the bytes in the string, so it may not behave
-/// entirely as expected for non-ASCII strings.
-///
-/// For a detailed explanation, check the example on Wikipedia: https://en.wikipedia.org/wiki/Levenshtein_distance
+/// For a detailed explanation, check the example on Wikipedia: <https://en.wikipedia.org/wiki/Levenshtein_distance>\
 /// (see the examples with the matrices, for instance between KITTEN and SITTING)
-/// Note that although we compute a matrix, left-to-right, top-to-bottom, at each step all we need to compute cell[i][j] is:
-///     * cell[i][j-1]
-///     * cell[i-j][j]
-///     * cell[i-i][j-1]
-/// This can be achieved by only using one "rolling" row and one additional variable, when computed cell[i][j] (or row[i]):
-///     * cell[i][j-1] is the value to the left, on the same row (the one we just computed, row[i-1])
-///     * cell[i-1][j] is the value at row[i], the one we're changing
-///     * cell[i-1][j-1] was the value at row[i-1] before we changed it, for that we'll use a variable
+///
+/// Note that although we compute a matrix, left-to-right, top-to-bottom, at each step all we need to compute `cell[i][j]` is:
+///   - `cell[i][j-1]`
+///   - `cell[i-j][j]`
+///   - `cell[i-i][j-1]`
+///
+/// This can be achieved by only using one "rolling" row and one additional variable, when computed `cell[i][j]` (or `row[i]`):
+///   - `cell[i][j-1]` is the value to the left, on the same row (the one we just computed, `row[i-1]`)
+///   - `cell[i-1][j]` is the value at `row[i]`, the one we're changing
+///   - `cell[i-1][j-1]` was the value at `row[i-1]` before we changed it, for that we'll use a variable
+///
 /// Doing this reduces space complexity from O(nm) to O(n)
 ///
 /// Second note: if we want to minimize space, since we're now O(n) make sure you use the shortest string horizontally, and the longest vertically
 ///
 /// # Complexity
-///
-/// - time complexity: O(nm),
-/// - space complexity: O(n),
+///   - time complexity: O(nm),
+///   - space complexity: O(n),
 ///
 /// where n and m are lengths of `str_a` and `str_b`
 pub fn levenshtein_distance(string1: &str, string2: &str) -> usize {


### PR DESCRIPTION
## Description

As mentioned in #488, I figured that I could help format the documentations in the source code so that `cargo doc` can better format them.

I took the liberty of rephrasing quite a chunk of the documentation of `stack_using_singly_linked_list` in order to improve the clarity of the explanation.
If I changed too much, or there's any degradation in the quality of explanation, I'd be happy to change it or revert that part of the change.

## Type of change
Refactoring/formatting.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.