### PR TITLE
Made Bell number computation more functional

### DIFF
--- a/src/math/bell_numbers.rs
+++ b/src/math/bell_numbers.rs
@@ -15,13 +15,9 @@ fn n_choose_r(n: u32, r: u32) -> BigUint {
     // Any combination will only need to be computed once, thus giving no need to
     // memoize this function
 
-    let mut product: BigUint = One::one();
-
-    for i in 0..r {
-        product *= BigUint::from(n - i);
-
-        product /= BigUint::from(i + 1);
-    }
+    let product: BigUint = (0..r).fold(BigUint::one(), |acc, x| {
+        (acc * BigUint::from(n - x)) / BigUint::from(x + 1)
+    });
 
     product
 }
@@ -92,11 +88,7 @@ pub fn bell_number(n: u32) -> BigUint {
         lookup_table.resize((n + 1) as usize);
     }
 
-    let mut new_bell_number = BigUint::zero();
-
-    for i in 0..n {
-        new_bell_number += bell_number(i) * n_choose_r(n - 1, i);
-    }
+    let new_bell_number: BigUint = (0..n).map(|x| bell_number(x) * n_choose_r(n - 1, x)).sum();
 
     // Add new number to lookup table
     {


### PR DESCRIPTION
# Pull Request Template

## Description

Replaced the for-loop computation in bell_numbers.rs with map() and fold().

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
