### PR TITLE
Clippy warning fixes

### DIFF
--- a/src/graph/depth_first_search_tic_tac_toe.rs
+++ b/src/graph/depth_first_search_tic_tac_toe.rs
@@ -274,7 +274,7 @@ fn append_playaction(
         return;
     }
 
-    let mut play_actions = opt_play_actions.as_mut().unwrap();
+    let play_actions = opt_play_actions.as_mut().unwrap();
 
     //New game action is scored from the current side and the current saved best score against the new game action.
     match (current_side, play_actions.side, appendee.side) {

--- a/src/math/pollard_rho.rs
+++ b/src/math/pollard_rho.rs
@@ -178,8 +178,7 @@ pub fn pollard_rho_factorize(
         return result;
     }
     let mut to_be_factored = vec![number];
-    while !to_be_factored.is_empty() {
-        let last = to_be_factored.pop().unwrap();
+    while let Some(last) = to_be_factored.pop() {
         if last < minimum_prime_factors.len() as u64 {
             result.append(&mut factor_using_mpf(last as usize, minimum_prime_factors));
             continue;


### PR DESCRIPTION
# Pull Request Template

## Description

Made 2 changes to code that was causing clippy warnings on the latest version of nightly rust.

First was an unneeded mut qualifier in src/graph/depth_first_search_tic_tac_toe.rs.
Second was a while loop that could be made into a while..let loop in src/math.pollard_rho.rs.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
