### PR TITLE
Area under curve algorithm

### DIFF
--- a/src/math/area_under_curve.rs
+++ b/src/math/area_under_curve.rs
@@ -1,0 +1,46 @@
+fn area_under_curve(start: f64, end: f64, func: fn(f64) -> f64, step_count: usize) -> f64 {
+    assert!(step_count > 0);
+
+    let (start, end) = if (start > end) { (end, start) } else { (start, end) }; //swap if bounds reversed
+
+    let step_length: f64 = (end - start) / step_count as f64;
+    let mut area: f64 = 0f64;
+    let mut fx1 = func(start);
+    let mut fx2: f64;
+
+    for eval_point in (1..step_count + 1).map(|x| (x as f64 * step_length) + start) {
+        fx2 = func(eval_point);
+        area += (fx2 + fx1).abs() * step_length * 0.5;
+        fx1 = fx2;
+    }
+
+    area
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_linear_func() {
+        assert_eq!(area_under_curve(1f64, 2f64, |x| x, 10), 1.5000000000000002);
+    }
+
+    #[test]
+    fn test_quadratic_func() {
+        assert_eq!(area_under_curve(1f64, 2f64, |x| x * x, 1000), 2.333333500000005);
+    }
+
+    #[test]
+    fn test_zero_length() {
+        assert_eq!(area_under_curve(0f64, 0f64, |x| x * x, 1000), 0.0);
+    }
+
+    #[test]
+    fn test_reverse() {
+        assert_eq!(
+            area_under_curve(1f64, 2f64, |x| x, 10),
+            area_under_curve(2f64, 1f64, |x| x, 10)
+        );
+    }
+}

--- a/src/math/area_under_curve.rs
+++ b/src/math/area_under_curve.rs
@@ -1,7 +1,11 @@
 fn area_under_curve(start: f64, end: f64, func: fn(f64) -> f64, step_count: usize) -> f64 {
     assert!(step_count > 0);
 
-    let (start, end) = if (start > end) { (end, start) } else { (start, end) }; //swap if bounds reversed
+    let (start, end) = if start > end {
+        (end, start)
+    } else {
+        (start, end)
+    }; //swap if bounds reversed
 
     let step_length: f64 = (end - start) / step_count as f64;
     let mut area: f64 = 0f64;
@@ -28,7 +32,10 @@ mod test {
 
     #[test]
     fn test_quadratic_func() {
-        assert_eq!(area_under_curve(1f64, 2f64, |x| x * x, 1000), 2.333333500000005);
+        assert_eq!(
+            area_under_curve(1f64, 2f64, |x| x * x, 1000),
+            2.333333500000005
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Added an algorithm for finding the area under a given function, between certain bounds.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
