### PR TITLE
Add the Tonelli-Shanks algorithm

### DIFF
--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -95,7 +95,7 @@ pub use self::pollard_rho::{pollard_rho_factorize, pollard_rho_get_one_factor};
 pub use self::prime_check::prime_check;
 pub use self::prime_factors::prime_factors;
 pub use self::prime_numbers::prime_numbers;
-pub use self::quadratic_residue::cipolla;
+pub use self::quadratic_residue::{cipolla, tonelli_shanks};
 pub use self::random::PCG32;
 pub use self::relu::relu;
 pub use self::sieve_of_eratosthenes::sieve_of_eratosthenes;


### PR DESCRIPTION
## Description

The algorithm computes quadratic residue modulo odd prime. The
implementation is simpler than the Cipolla algorithm. The algorithm
is planned to be used in Baby-Step-Giant-Step algorithm of counting
points on elliptic curve.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.