### PR TITLE
Imporve heap

### DIFF
--- a/src/data_structures/heap.rs
+++ b/src/data_structures/heap.rs
@@ -1,36 +1,27 @@
 // Heap data structure
 // Takes a closure as a comparator to allow for min-heap, max-heap, and works with custom key functions
 
-use std::cmp::Ord;
-use std::default::Default;
+use std::{cmp::Ord, slice::Iter};
 
-pub struct Heap<T>
-where
-    T: Default,
-{
-    count: usize,
+pub struct Heap<T> {
     items: Vec<T>,
     comparator: fn(&T, &T) -> bool,
 }
 
-impl<T> Heap<T>
-where
-    T: Default,
-{
+impl<T> Heap<T> {
     pub fn new(comparator: fn(&T, &T) -> bool) -> Self {
         Self {
-            count: 0,
             // Add a default in the first spot to offset indexes
             // for the parent/child math to work out.
             // Vecs have to have all the same type so using Default
             // is a way to add an unused item.
-            items: vec![T::default()],
+            items: vec![],
             comparator,
         }
     }
 
     pub fn len(&self) -> usize {
-        self.count
+        self.items.len()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -38,13 +29,11 @@ where
     }
 
     pub fn add(&mut self, value: T) {
-        self.count += 1;
         self.items.push(value);
 
         // Heapify Up
-        let mut idx = self.count;
-        while self.parent_idx(idx) > 0 {
-            let pdx = self.parent_idx(idx);
+        let mut idx = self.len() - 1;
+        while let Some(pdx) = self.parent_idx(idx) {
             if (self.comparator)(&self.items[idx], &self.items[pdx]) {
                 self.items.swap(idx, pdx);
             }
@@ -52,40 +41,70 @@ where
         }
     }
 
-    fn parent_idx(&self, idx: usize) -> usize {
-        idx / 2
+    pub fn pop(&mut self) -> Option<T> {
+        if self.is_empty() {
+            return None;
+        }
+        // This feels like a function built for heap impl :)
+        // Removes an item at an index and fills in with the last item
+        // of the Vec
+        let next = Some(self.items.swap_remove(0));
+
+        if !self.is_empty() {
+            // Heapify Down
+            let mut idx = 0;
+            while self.children_present(idx) {
+                let cdx = {
+                    if self.right_child_idx(idx) >= self.len() {
+                        self.left_child_idx(idx)
+                    } else {
+                        let ldx = self.left_child_idx(idx);
+                        let rdx = self.right_child_idx(idx);
+                        if (self.comparator)(&self.items[ldx], &self.items[rdx]) {
+                            ldx
+                        } else {
+                            rdx
+                        }
+                    }
+                };
+                if !(self.comparator)(&self.items[idx], &self.items[cdx]) {
+                    self.items.swap(idx, cdx);
+                }
+                idx = cdx;
+            }
+        }
+
+        next
+    }
+
+    pub fn iter(&self) -> Iter<'_, T> {
+        self.items.iter()
+    }
+
+    fn parent_idx(&self, idx: usize) -> Option<usize> {
+        if idx > 0 {
+            Some((idx - 1) / 2)
+        } else {
+            None
+        }
     }
 
     fn children_present(&self, idx: usize) -> bool {
-        self.left_child_idx(idx) <= self.count
+        self.left_child_idx(idx) <= (self.len() - 1)
     }
 
     fn left_child_idx(&self, idx: usize) -> usize {
-        idx * 2
+        idx * 2 + 1
     }
 
     fn right_child_idx(&self, idx: usize) -> usize {
         self.left_child_idx(idx) + 1
     }
-
-    fn smallest_child_idx(&self, idx: usize) -> usize {
-        if self.right_child_idx(idx) > self.count {
-            self.left_child_idx(idx)
-        } else {
-            let ldx = self.left_child_idx(idx);
-            let rdx = self.right_child_idx(idx);
-            if (self.comparator)(&self.items[ldx], &self.items[rdx]) {
-                ldx
-            } else {
-                rdx
-            }
-        }
-    }
 }
 
 impl<T> Heap<T>
 where
-    T: Default + Ord,
+    T: Ord,
 {
     /// Create a new MinHeap
     pub fn new_min() -> Heap<T> {
@@ -98,45 +117,13 @@ where
     }
 }
 
-impl<T> Iterator for Heap<T>
-where
-    T: Default,
-{
-    type Item = T;
-
-    fn next(&mut self) -> Option<T> {
-        if self.count == 0 {
-            return None;
-        }
-        // This feels like a function built for heap impl :)
-        // Removes an item at an index and fills in with the last item
-        // of the Vec
-        let next = Some(self.items.swap_remove(1));
-        self.count -= 1;
-
-        if self.count > 0 {
-            // Heapify Down
-            let mut idx = 1;
-            while self.children_present(idx) {
-                let cdx = self.smallest_child_idx(idx);
-                if !(self.comparator)(&self.items[idx], &self.items[cdx]) {
-                    self.items.swap(idx, cdx);
-                }
-                idx = cdx;
-            }
-        }
-
-        next
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     #[test]
     fn test_empty_heap() {
         let mut heap: Heap<i32> = Heap::new_max();
-        assert_eq!(heap.next(), None);
+        assert_eq!(heap.pop(), None);
     }
 
     #[test]
@@ -147,11 +134,11 @@ mod tests {
         heap.add(9);
         heap.add(11);
         assert_eq!(heap.len(), 4);
-        assert_eq!(heap.next(), Some(2));
-        assert_eq!(heap.next(), Some(4));
-        assert_eq!(heap.next(), Some(9));
+        assert_eq!(heap.pop(), Some(2));
+        assert_eq!(heap.pop(), Some(4));
+        assert_eq!(heap.pop(), Some(9));
         heap.add(1);
-        assert_eq!(heap.next(), Some(1));
+        assert_eq!(heap.pop(), Some(1));
     }
 
     #[test]
@@ -162,14 +149,13 @@ mod tests {
         heap.add(9);
         heap.add(11);
         assert_eq!(heap.len(), 4);
-        assert_eq!(heap.next(), Some(11));
-        assert_eq!(heap.next(), Some(9));
-        assert_eq!(heap.next(), Some(4));
+        assert_eq!(heap.pop(), Some(11));
+        assert_eq!(heap.pop(), Some(9));
+        assert_eq!(heap.pop(), Some(4));
         heap.add(1);
-        assert_eq!(heap.next(), Some(2));
+        assert_eq!(heap.pop(), Some(2));
     }
 
-    #[derive(Default)]
     struct Point(/* x */ i32, /* y */ i32);
 
     #[test]
@@ -179,9 +165,34 @@ mod tests {
         heap.add(Point(3, 10));
         heap.add(Point(-2, 4));
         assert_eq!(heap.len(), 3);
-        assert_eq!(heap.next().unwrap().0, -2);
-        assert_eq!(heap.next().unwrap().0, 1);
+        assert_eq!(heap.pop().unwrap().0, -2);
+        assert_eq!(heap.pop().unwrap().0, 1);
         heap.add(Point(50, 34));
-        assert_eq!(heap.next().unwrap().0, 3);
+        assert_eq!(heap.pop().unwrap().0, 3);
+    }
+
+    #[test]
+    fn test_iter_heap() {
+        let mut heap = Heap::new_min();
+        heap.add(4);
+        heap.add(2);
+        heap.add(9);
+        heap.add(11);
+
+        // test iterator, which is not in order except the first one.
+        let mut iter = heap.iter();
+        assert_eq!(iter.next(), Some(&2));
+        assert_ne!(iter.next(), None);
+        assert_ne!(iter.next(), None);
+        assert_ne!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+
+        // test the heap after run iterator.
+        assert_eq!(heap.len(), 4);
+        assert_eq!(heap.pop(), Some(2));
+        assert_eq!(heap.pop(), Some(4));
+        assert_eq!(heap.pop(), Some(9));
+        assert_eq!(heap.pop(), Some(11));
+        assert_eq!(heap.pop(), None);
     }
 }

--- a/src/searching/kth_smallest_heap.rs
+++ b/src/searching/kth_smallest_heap.rs
@@ -12,7 +12,7 @@ use std::cmp::{Ord, Ordering};
 /// operation's complexity is O(log(k)).
 pub fn kth_smallest_heap<T>(input: &[T], k: usize) -> Option<T>
 where
-    T: Default + Ord + Copy,
+    T: Ord + Copy,
 {
     if input.len() < k {
         return None;
@@ -37,7 +37,7 @@ where
 
     for &val in input.iter().skip(k) {
         // compare new value to the current kth smallest value
-        let cur_big = heap.next().unwrap(); // heap.next() can't be None
+        let cur_big = heap.pop().unwrap(); // heap.pop() can't be None
         match val.cmp(&cur_big) {
             Ordering::Greater => {
                 heap.add(cur_big);
@@ -48,7 +48,7 @@ where
         }
     }
 
-    heap.next()
+    heap.pop()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# heap problem

## Description

* Let heap's data container vec start from the index zero, no need to waste one space.
* No need to let T impl Default trait if Vec starts from index zero;
* Iterator is not used to change the heap data, so I use `fn pop()` to replace it;
* Iterator for the min/max heap doesn't make sense, but I added an impl one anyway;
* smallest_child_idx fn don't make sense, it's the process of shift down, so I inline it inside the `fn pop()`;

I notice there are 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

