### PR TITLE
Intialized bit manipulation section and implemented counting bits

### DIFF
--- a/src/bit_manipulation/counting_bits.rs
+++ b/src/bit_manipulation/counting_bits.rs
@@ -1,0 +1,46 @@
+/*
+The counting bits algorithm, also known as the "population count" or "Hamming weight,"
+calculates the number of set bits (1s) in the binary representation of an unsigned integer.
+It uses a technique known as Brian Kernighan's algorithm, which efficiently clears the least
+significant set bit in each iteration.
+*/
+
+pub fn count_set_bits(mut n: u32) -> u32 {
+    // Initialize a variable to keep track of the count of set bits
+    let mut count = 0;
+    while n > 0 {
+        // Clear the least significant set bit by
+        // performing a bitwise AND operation with (n - 1)
+        n &= n - 1;
+
+        // Increment the count for each set bit found
+        count += 1;
+    }
+
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_count_set_bits_zero() {
+        assert_eq!(count_set_bits(0), 0);
+    }
+
+    #[test]
+    fn test_count_set_bits_one() {
+        assert_eq!(count_set_bits(1), 1);
+    }
+
+    #[test]
+    fn test_count_set_bits_power_of_two() {
+        assert_eq!(count_set_bits(16), 1); // 16 is 2^4, only one set bit
+    }
+
+    #[test]
+    fn test_count_set_bits_all_set_bits() {
+        assert_eq!(count_set_bits(u32::MAX), 32); // Maximum value for u32, all set bits
+    }
+}

--- a/src/bit_manipulation/mod.rs
+++ b/src/bit_manipulation/mod.rs
@@ -1,0 +1,3 @@
+mod counting_bits;
+
+pub use counting_bits::count_set_bits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate lazy_static;
 pub mod backtracking;
 pub mod big_integer;
+pub mod bit_manipulation;
 pub mod ciphers;
 pub mod compression;
 pub mod conversions;


### PR DESCRIPTION
## Description

This PR adds a new Rust file count_set_bits.rs to the bit_manipulation directory. It includes an implementation of the "Counting Set Bits" algorithm, which efficiently calculates the number of set bits (1s) in the binary representation of a 32-bit unsigned integer.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (bit manipulation section)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
