### PR TITLE
add `huber_loss` and `cross_entropy_loss` and doc for gelu function

### DIFF
--- a/src/math/cross_entropy_loss.rs
+++ b/src/math/cross_entropy_loss.rs
@@ -1,0 +1,40 @@
+//! # Cross-Entropy Loss Function
+//!
+//! The `cross_entropy_loss` function calculates the cross-entropy loss between the actual and predicted probability distributions.
+//!
+//! Cross-entropy loss is commonly used in machine learning and deep learning to measure the dissimilarity between two probability distributions. It is often used in classification problems.
+//!
+//! ## Formula
+//!
+//! For a pair of actual and predicted probability distributions represented as vectors `actual` and `predicted`, the cross-entropy loss is calculated as:
+//!
+//! `L = -Σ(actual[i] * ln(predicted[i]))` for all `i` in the range of the vectors
+//!
+//! Where `ln` is the natural logarithm function, and `Σ` denotes the summation over all elements of the vectors.
+//!
+//! ## Cross-Entropy Loss Function Implementation
+//!
+//! This implementation takes two references to vectors of f64 values, `actual` and `predicted`, and returns the cross-entropy loss between them.
+//!
+pub fn cross_entropy_loss(actual: &[f64], predicted: &[f64]) -> f64 {
+    let mut loss: Vec<f64> = Vec::new();
+    for (a, p) in actual.iter().zip(predicted.iter()) {
+        loss.push(-a * p.ln());
+    }
+    loss.iter().sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cross_entropy_loss() {
+        let test_vector_actual = vec![0., 1., 0., 0., 0., 0.];
+        let test_vector = vec![0.1, 0.7, 0.1, 0.05, 0.05, 0.1];
+        assert_eq!(
+            cross_entropy_loss(&test_vector_actual, &test_vector),
+            0.35667494393873245
+        );
+    }
+}

--- a/src/math/gaussian_error_linear_unit.rs
+++ b/src/math/gaussian_error_linear_unit.rs
@@ -1,3 +1,22 @@
+//! # Gaussian Error Linear Unit (GELU) Function
+//!
+//! The `gaussian_error_linear_unit` function computes the Gaussian Error Linear Unit (GELU) values of a given f64 number or a vector of f64 numbers.
+//!
+//! GELU is an activation function used in neural networks that introduces a smooth approximation of the rectifier function (ReLU).
+//! It is defined using the Gaussian cumulative distribution function and can help mitigate the vanishing gradient problem.
+//!
+//! ## Formula
+//!
+//! For a given input value `x`, the GELU function computes the output `y` as follows:
+//!
+//! `y = 0.5 * (1.0 + tanh(2.0 / sqrt(π) * (x + 0.044715 * x^3)))`
+//!
+//! Where `tanh` is the hyperbolic tangent function and `π` is the mathematical constant (approximately 3.14159).
+//!
+//! ## Gaussian Error Linear Unit (GELU) Function Implementation
+//!
+//! This implementation takes either a single f64 value or a reference to a vector of f64 values and returns the GELU transformation applied to each element. The input values are not altered.
+//!
 use std::f64::consts::E;
 use std::f64::consts::PI;
 

--- a/src/math/huber_loss.rs
+++ b/src/math/huber_loss.rs
@@ -1,0 +1,43 @@
+//! # Huber Loss Function
+//!
+//! The `huber_loss` function calculates the Huber loss, which is a robust loss function used in machine learning, particularly in regression problems.
+//!
+//! Huber loss combines the benefits of mean squared error (MSE) and mean absolute error (MAE). It behaves like MSE when the difference between actual and predicted values is small (less than a specified `delta`), and like MAE when the difference is large.
+//!
+//! ## Formula
+//!
+//! For a pair of actual and predicted values, represented as vectors `actual` and `predicted`, and a specified `delta` value, the Huber loss is calculated as:
+//!
+//! - If the absolute difference between `actual[i]` and `predicted[i]` is less than or equal to `delta`, the loss is `0.5 * (actual[i] - predicted[i])^2`.
+//! - If the absolute difference is greater than `delta`, the loss is `delta * |actual[i] - predicted[i]| - 0.5 * delta`.
+//!
+//! The total loss is the sum of individual losses over all elements.
+//!
+//! ## Huber Loss Function Implementation
+//!
+//! This implementation takes two references to vectors of f64 values, `actual` and `predicted`, and a `delta` value. It returns the Huber loss between them, providing a robust measure of dissimilarity between actual and predicted values.
+//!
+pub fn huber_loss(actual: &[f64], predicted: &[f64], delta: f64) -> f64 {
+    let mut loss: Vec<f64> = Vec::new();
+    for (a, p) in actual.iter().zip(predicted.iter()) {
+        if (a - p).abs() <= delta {
+            loss.push(0.5 * (a - p).powf(2.));
+        } else {
+            loss.push(delta * (a - p).abs() - (0.5 * delta));
+        }
+    }
+
+    loss.iter().sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_huber_loss() {
+        let test_vector_actual = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let test_vector = vec![5.0, 7.0, 9.0, 11.0, 13.0];
+        assert_eq!(huber_loss(&test_vector_actual, &test_vector, 1.0), 27.5);
+    }
+}

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -9,6 +9,7 @@ mod binary_exponentiation;
 mod ceil;
 mod chinese_remainder_theorem;
 mod collatz_sequence;
+mod cross_entropy_loss;
 mod doomsday;
 mod elliptic_curve;
 mod exponential_linear_unit;
@@ -22,6 +23,7 @@ mod gaussian_elimination;
 mod gaussian_error_linear_unit;
 mod gcd_of_n_numbers;
 mod greatest_common_divisor;
+mod huber_loss;
 mod interest;
 mod interpolation;
 mod karatsuba_multiplication;
@@ -66,6 +68,7 @@ pub use self::binary_exponentiation::binary_exponentiation;
 pub use self::ceil::ceil;
 pub use self::chinese_remainder_theorem::chinese_remainder_theorem;
 pub use self::collatz_sequence::sequence;
+pub use self::cross_entropy_loss::cross_entropy_loss;
 pub use self::doomsday::get_week_day;
 pub use self::elliptic_curve::EllipticCurve;
 pub use self::exponential_linear_unit::exponential_linear_unit;
@@ -85,6 +88,7 @@ pub use self::greatest_common_divisor::{
     greatest_common_divisor_iterative, greatest_common_divisor_recursive,
     greatest_common_divisor_stein,
 };
+pub use self::huber_loss::huber_loss;
 pub use self::interest::{compound_interest, simple_interest};
 pub use self::interpolation::{lagrange_polynomial_interpolation, linear_interpolation};
 pub use self::karatsuba_multiplication::multiply;


### PR DESCRIPTION
## Description
### Huber Loss Function:
Huber loss is a regression loss function that balances the benefits of Mean Squared Error (MSE) and Mean Absolute Error (MAE). It behaves like MSE for small differences between actual and predicted values and switches to MAE for larger differences, making it robust to outliers.

### Cross-Entropy Loss Function:
Cross-entropy loss is a classification loss function that measures the dissimilarity between actual and predicted probability distributions. It is widely used in tasks where data points need to be classified into different classes based on predicted probabilities.

covers part of #559 

Both functions contribute to the project's functionality, expanding its capabilities for machine learning and neural network applications.