### PR TITLE
Implementation of Fizzy Number Program in Rust

### DIFF
--- a/src/math/frizzy_number.rs
+++ b/src/math/frizzy_number.rs
@@ -1,0 +1,61 @@
+/// This Rust program calculates the n-th Frizzy number for a given base.
+/// A Frizzy number is defined as the n-th number that is a sum of powers
+/// of the given base, with the powers corresponding to the binary representation
+/// of n.
+
+/// The `get_nth_frizzy` function takes two arguments:
+/// * `base` - The base whose n-th sum of powers is required.
+/// * `n` - Index from ascending order of the sum of powers of the base.
+
+/// It returns the n-th sum of powers of the base.
+
+/// # Example
+/// To find the Frizzy number with a base of 3 and n equal to 4:
+/// - Ascending order of sums of powers of 3: 3^0 = 1, 3^1 = 3, 3^1 + 3^0 = 4, 3^2 + 3^0 = 9.
+/// - The answer is 9.
+///
+/// # Arguments
+/// * `base` - The base whose n-th sum of powers is required.
+/// * `n` - Index from ascending order of the sum of powers of the base.
+///
+/// # Returns
+/// The n-th sum of powers of the base.
+
+pub fn get_nth_frizzy(base: i32, mut n: i32) -> f64 {
+    let mut final1 = 0.0;
+    let mut i = 0;
+    while n > 0 {
+        final1 += (base.pow(i) as f64) * ((n % 2) as f64);
+        i += 1;
+        n /= 2;
+    }
+    final1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_nth_frizzy() {
+        // Test case 1: base = 3, n = 4
+        // 3^2 + 3^0 = 9
+        assert_eq!(get_nth_frizzy(3, 4), 9.0);
+
+        // Test case 2: base = 2, n = 5
+        // 2^2 + 2^0 = 5
+        assert_eq!(get_nth_frizzy(2, 5), 5.0);
+
+        // Test case 3: base = 4, n = 3
+        // 4^1 + 4^0 = 5
+        assert_eq!(get_nth_frizzy(4, 3), 5.0);
+
+        // Test case 4: base = 5, n = 2
+        // 5^1 + 5^0 = 5
+        assert_eq!(get_nth_frizzy(5, 2), 5.0);
+
+        // Test case 5: base = 6, n = 1
+        // 6^0 = 1
+        assert_eq!(get_nth_frizzy(6, 1), 1.0);
+    }
+}

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -20,6 +20,7 @@ mod fast_fourier_transform;
 mod fast_power;
 mod faster_perfect_numbers;
 mod field;
+mod frizzy_number;
 mod gaussian_elimination;
 mod gaussian_error_linear_unit;
 mod gcd_of_n_numbers;
@@ -84,6 +85,7 @@ pub use self::fast_fourier_transform::{
 pub use self::fast_power::fast_power;
 pub use self::faster_perfect_numbers::generate_perfect_numbers;
 pub use self::field::{Field, PrimeField};
+pub use self::frizzy_number::get_nth_frizzy;
 pub use self::gaussian_elimination::gaussian_elimination;
 pub use self::gaussian_error_linear_unit::gaussian_error_linear_unit;
 pub use self::gcd_of_n_numbers::gcd;


### PR DESCRIPTION
This pull request adds a Rust implementation of the Fizzy Number program, which calculates the n-th number that is a sum of powers of a given base. The code is well-documented with comments and includes five test cases to ensure correctness.

Hope adding this code in the repo would be helpful for the community.

Please review!