### PR TITLE
tests: add test covering the `common_ratio == 1.0` case

### DIFF
--- a/src/math/sum_of_geometric_progression.rs
+++ b/src/math/sum_of_geometric_progression.rs
@@ -26,5 +26,8 @@ mod tests {
 
         let result_3 = sum_of_geometric_progression(9.0, 2.5, 5);
         assert_eq!(result_3, 579.9375);
+
+        let result_4 = sum_of_geometric_progression(10.0, 1.0, 3);
+        assert_eq!(result_4, 30.0);
     }
 }

--- a/src/math/sum_of_geometric_progression.rs
+++ b/src/math/sum_of_geometric_progression.rs
@@ -16,18 +16,22 @@ pub fn sum_of_geometric_progression(first_term: f64, common_ratio: f64, num_of_t
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_sum_of_geometric_progression() {
-        let result_1 = sum_of_geometric_progression(1.0, 2.0, 10);
-        assert_eq!(result_1, 1023.0);
+    macro_rules! test_sum_of_geometric_progression {
+        ($($name:ident: $inputs:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let (first_term, common_ratio, num_of_terms, expected) = $inputs;
+                assert_eq!(sum_of_geometric_progression(first_term, common_ratio, num_of_terms), expected);
+            }
+        )*
+        }
+    }
 
-        let result_2 = sum_of_geometric_progression(1.0, 10.0, 5);
-        assert_eq!(result_2, 11111.0);
-
-        let result_3 = sum_of_geometric_progression(9.0, 2.5, 5);
-        assert_eq!(result_3, 579.9375);
-
-        let result_4 = sum_of_geometric_progression(10.0, 1.0, 3);
-        assert_eq!(result_4, 30.0);
+    test_sum_of_geometric_progression! {
+        regular_input_0: (1.0, 2.0, 10, 1023.0),
+        regular_input_1: (1.0, 10.0, 5, 11111.0),
+        regular_input_2: (9.0, 2.5, 5, 579.9375),
+        common_ratio_one: (10.0, 1.0, 3, 30.0),
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds a test covering this line:
https://github.com/TheAlgorithms/Rust/blob/cef88b414f2d1b42551aa1bc5643f52be02feb37/src/math/sum_of_geometric_progression.rs#L8

I decided to update the structure of the corresponding tests and and express them like _parametrized_-like tests.

It seems that `graph::astar::tests::test_heuristic` [sometimes fails](https://github.com/TheAlgorithms/Rust/actions/runs/6776209984/job/18417199500#step:3:1030).

## Type of change

- [x] adds missing test case,

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] ~I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).~
- [x] ~I added my algorithm to `DIRECTORY.md` with the correct link.~
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
