### PR TITLE
Update documentation of `average.rs`

### DIFF
--- a/src/math/average.rs
+++ b/src/math/average.rs
@@ -7,7 +7,7 @@ The mode is the most frequently occurring value on the list.
 Reference: https://www.britannica.com/science/mean-median-and-mode
 
 This program approximates the mean, median and mode of a finite sequence.
-Note: `mean` function only limited to float 64 numbers. Floats sequences are not allowed for `median` & `mode` functions.
+Note: `mean` function only limited to float 64 numbers. Floats sequences are not allowed for `mode` function.
 "]
 use std::collections::HashMap;
 use std::collections::HashSet;


### PR DESCRIPTION
# Pull Request Template

## Description

After merging #601, `median` allows `f64` inputs. I have overlooked it back then.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
