### PR TITLE
Handle empty input in `median`

### DIFF
--- a/src/math/average.rs
+++ b/src/math/average.rs
@@ -30,14 +30,17 @@ fn mean_of_two<T: Num + Copy>(a: T, b: T) -> T {
 /// * `sequence` - A vector of numbers.
 /// Returns median of `sequence`.
 
-pub fn median<T: Num + Copy + PartialOrd>(mut sequence: Vec<T>) -> T {
+pub fn median<T: Num + Copy + PartialOrd>(mut sequence: Vec<T>) -> Option<T> {
+    if sequence.is_empty() {
+        return None;
+    }
     sequence.sort_by(|a, b| a.partial_cmp(b).unwrap());
     if sequence.len() % 2 == 1 {
         let k = (sequence.len() + 1) / 2;
-        sequence[k - 1]
+        Some(sequence[k - 1])
     } else {
         let j = (sequence.len()) / 2;
-        mean_of_two(sequence[j - 1], sequence[j])
+        Some(mean_of_two(sequence[j - 1], sequence[j]))
     }
 }
 
@@ -66,11 +69,13 @@ mod test {
     use super::*;
     #[test]
     fn median_test() {
-        assert_eq!(median(vec![4, 53, 2, 1, 9, 0, 2, 3, 6]), 3);
-        assert_eq!(median(vec![-9, -8, 0, 1, 2, 2, 3, 4, 6, 9, 53]), 2);
-        assert_eq!(median(vec![2, 3]), 2);
-        assert_eq!(median(vec![3.0, 2.0]), 2.5);
-        assert_eq!(median(vec![1.0, 700.0, 5.0]), 5.0);
+        assert_eq!(median(vec![4, 53, 2, 1, 9, 0, 2, 3, 6]).unwrap(), 3);
+        assert_eq!(median(vec![-9, -8, 0, 1, 2, 2, 3, 4, 6, 9, 53]).unwrap(), 2);
+        assert_eq!(median(vec![2, 3]).unwrap(), 2);
+        assert_eq!(median(vec![3.0, 2.0]).unwrap(), 2.5);
+        assert_eq!(median(vec![1.0, 700.0, 5.0]).unwrap(), 5.0);
+        assert!(median(Vec::<i32>::new()).is_none());
+        assert!(median(Vec::<f64>::new()).is_none());
     }
     #[test]
     fn mode_test() {


### PR DESCRIPTION
# Pull Request Template

## Description

The [`median`](https://github.com/TheAlgorithms/Rust/blob/ed801737834477d35c39f35aa9eca20a2b062f1b/src/math/average.rs#L33C18-L33C18) function crashes for empty inputs. Since there is no `nan` for types integer types, I decided to return `Option<T>` from `median`. 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) (well, I change the return type, but _everything works_).

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
