### PR TITLE
Make `mean` generic

### DIFF
--- a/src/math/average.rs
+++ b/src/math/average.rs
@@ -7,19 +7,28 @@ The mode is the most frequently occurring value on the list.
 Reference: https://www.britannica.com/science/mean-median-and-mode
 
 This program approximates the mean, median and mode of a finite sequence.
-Note: `mean` function only limited to float 64 numbers. Floats sequences are not allowed for `mode` function.
+Note: Floats sequences are not allowed for `mode` function.
 "]
 use std::collections::HashMap;
 use std::collections::HashSet;
-/// # Argument
-///
-/// * `sequence` - A vector of float64 numbers.
-/// Returns mean of `sequence`.
-pub fn mean(sequence: Vec<f64>) -> f64 {
-    sequence.iter().sum::<f64>() / (sequence.len() as f64)
-}
 
 use num_traits::Num;
+
+fn sum<T: Num + Copy>(sequence: Vec<T>) -> T {
+    sequence.iter().fold(T::zero(), |acc, x| acc + *x)
+}
+
+/// # Argument
+///
+/// * `sequence` - A vector of numbers.
+/// Returns mean of `sequence`.
+pub fn mean<T: Num + Copy + num_traits::FromPrimitive>(sequence: Vec<T>) -> Option<T> {
+    let len = sequence.len();
+    if len == 0 {
+        return None;
+    }
+    Some(sum(sequence) / (T::from_usize(len).unwrap()))
+}
 
 fn mean_of_two<T: Num + Copy>(a: T, b: T) -> T {
     (a + b) / (T::one() + T::one())
@@ -100,12 +109,14 @@ mod test {
     }
     #[test]
     fn mean_test() {
-        assert_eq!(mean(vec![2023.1112]), 2023.1112);
-        assert_eq!(mean(vec![0.0, 1.0, 2.0, 3.0, 4.0]), 2.0);
+        assert_eq!(mean(vec![2023.1112]).unwrap(), 2023.1112);
+        assert_eq!(mean(vec![0.0, 1.0, 2.0, 3.0, 4.0]).unwrap(), 2.0);
         assert_eq!(
-            mean(vec![-7.0, 4.0, 53.0, 2.0, 1.0, -9.0, 0.0, 2.0, 3.0, -6.0]),
+            mean(vec![-7.0, 4.0, 53.0, 2.0, 1.0, -9.0, 0.0, 2.0, 3.0, -6.0]).unwrap(),
             4.3
         );
-        assert!(mean(Vec::<f64>::new()).is_nan());
+        assert_eq!(mean(vec![1, 2]).unwrap(), 1);
+        assert!(mean(Vec::<f64>::new()).is_none());
+        assert!(mean(Vec::<i32>::new()).is_none());
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR makes the [`mean`](https://github.com/TheAlgorithms/Rust/blob/1ba5fc7d6cd61d18fe2b9c4dc1baaf4c0dd2c123/src/math/average.rs#L18) generic. It also changes the return type to `Option<T>` to deal with empty inputs.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) - change of the return type

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
