### PR TITLE
Fix bug in `fast_factorial`

### DIFF
--- a/src/big_integer/fast_factorial.rs
+++ b/src/big_integer/fast_factorial.rs
@@ -37,7 +37,7 @@ pub fn fast_factorial(n: usize) -> BigUint {
         p_indeces.insert(p, index(p, n));
     });
 
-    let max_bits = p_indeces.get(&2).unwrap().next_power_of_two().ilog2();
+    let max_bits = p_indeces.get(&2).unwrap().next_power_of_two().ilog2() + 1;
 
     // Create a Vec of 1's
     let mut a = Vec::with_capacity(max_bits as usize);
@@ -68,7 +68,19 @@ mod tests {
 
     #[test]
     fn fact() {
+        assert_eq!(fast_factorial(0), BigUint::one());
+        assert_eq!(fast_factorial(1), BigUint::one());
+        assert_eq!(fast_factorial(2), factorial(2));
+        assert_eq!(fast_factorial(3), factorial(3));
+        assert_eq!(fast_factorial(6), factorial(6));
+        assert_eq!(fast_factorial(7), factorial(7));
+        assert_eq!(fast_factorial(10), factorial(10));
+        assert_eq!(fast_factorial(11), factorial(11));
+        assert_eq!(fast_factorial(18), factorial(18));
+        assert_eq!(fast_factorial(19), factorial(19));
         assert_eq!(fast_factorial(30), factorial(30));
+        assert_eq!(fast_factorial(34), factorial(34));
+        assert_eq!(fast_factorial(35), factorial(35));
         assert_eq!(fast_factorial(52), factorial(52));
         assert_eq!(fast_factorial(100), factorial(100));
         assert_eq!(fast_factorial(1000), factorial(1000));


### PR DESCRIPTION
# Pull Request Template

## Description

There is a bug in [`fast_factorial`](https://github.com/TheAlgorithms/Rust/blob/ce1be6a9a60d307bb6427dac24b024fea40f75ab/src/big_integer/fast_factorial.rs#L25). Below there examples of inputs, for which `fast_factorial` gives different results as [`factorial`](https://github.com/TheAlgorithms/Rust/blob/ce1be6a9a60d307bb6427dac24b024fea40f75ab/src/big_integer/hello_bigmath.rs#L6):
```
n: 2 fast_fac: 1 fac: 2
n: 3 fast_fac: 1 fac: 6
n: 6 fast_fac: 45 fac: 720
n: 7 fast_fac: 315 fac: 5040
n: 10 fast_fac: 14175 fac: 3628800
n: 11 fast_fac: 155925 fac: 39916800
n: 18 fast_fac: 97692469875 fac: 6402373705728000
n: 19 fast_fac: 1856156927625 fac: 121645100408832000
n: 34 fast_fac: 68739242628124575327993046875 fac: 295232799039604140847618609643520000000
```

This PR:
- fixes the menioned bug,
- adds tests _covering_ this line: https://github.com/TheAlgorithms/Rust/blob/ce1be6a9a60d307bb6427dac24b024fea40f75ab/src/big_integer/fast_factorial.rs#L27 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
