### PR TITLE
Update `aliquot_sum`

### DIFF
--- a/src/math/aliquot_sum.rs
+++ b/src/math/aliquot_sum.rs
@@ -46,8 +46,15 @@ mod tests {
         test_with_4: (4, 1+2),
         test_with_5: (5, 1),
         test_with_6: (6, 6),
+        test_with_7: (7, 1),
+        test_with_8: (8, 1+2+4),
+        test_with_9: (9, 1+3),
+        test_with_10: (10, 1+2+5),
         test_with_15: (15, 9),
         test_with_343: (343, 57),
+        test_with_344: (344, 316),
+        test_with_500: (500, 592),
+        test_with_501: (501, 171),
     }
 
     #[test]

--- a/src/math/aliquot_sum.rs
+++ b/src/math/aliquot_sum.rs
@@ -10,18 +10,8 @@ pub fn aliquot_sum(number: u64) -> u64 {
     if number == 0 {
         panic!("Input has to be positive.")
     }
-    if number == 1 {
-        return 0;
-    }
-    let mut sum: u64 = 0;
 
-    for i in 1..(number / 2 + 1) {
-        if number % i == 0 {
-            sum += i;
-        }
-    }
-
-    sum
+    (1..=number / 2).filter(|&d| number % d == 0).sum()
 }
 
 #[cfg(test)]

--- a/src/math/aliquot_sum.rs
+++ b/src/math/aliquot_sum.rs
@@ -7,7 +7,10 @@
 /// Wikipedia article on Aliquot Sum: <https://en.wikipedia.org/wiki/Aliquot_sum>
 
 pub fn aliquot_sum(number: u64) -> u64 {
-    if number == 1 || number == 0 {
+    if number == 0 {
+        panic!("Input has to be positive.")
+    }
+    if number == 1 {
         return 0;
     }
     let mut sum: u64 = 0;
@@ -38,5 +41,11 @@ mod tests {
     #[test]
     fn three_digit_number() {
         assert_eq!(aliquot_sum(343), 57);
+    }
+
+    #[test]
+    #[should_panic]
+    fn panics_if_input_is_zero() {
+        aliquot_sum(0);
     }
 }

--- a/src/math/aliquot_sum.rs
+++ b/src/math/aliquot_sum.rs
@@ -29,6 +29,16 @@ mod tests {
     use super::*;
 
     #[test]
+    fn two_with_1() {
+        assert_eq!(aliquot_sum(1), 0);
+    }
+
+    #[test]
+    fn two_with_2() {
+        assert_eq!(aliquot_sum(2), 1);
+    }
+
+    #[test]
     fn one_digit_number() {
         assert_eq!(aliquot_sum(6), 6);
     }

--- a/src/math/aliquot_sum.rs
+++ b/src/math/aliquot_sum.rs
@@ -28,29 +28,26 @@ pub fn aliquot_sum(number: u64) -> u64 {
 mod tests {
     use super::*;
 
-    #[test]
-    fn two_with_1() {
-        assert_eq!(aliquot_sum(1), 0);
+    macro_rules! test_aliquot_sum {
+        ($($name:ident: $tc:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let (number, expected) = $tc;
+                assert_eq!(aliquot_sum(number), expected);
+            }
+        )*
+        }
     }
-
-    #[test]
-    fn two_with_2() {
-        assert_eq!(aliquot_sum(2), 1);
-    }
-
-    #[test]
-    fn one_digit_number() {
-        assert_eq!(aliquot_sum(6), 6);
-    }
-
-    #[test]
-    fn two_digit_number() {
-        assert_eq!(aliquot_sum(15), 9);
-    }
-
-    #[test]
-    fn three_digit_number() {
-        assert_eq!(aliquot_sum(343), 57);
+    test_aliquot_sum! {
+        test_with_1: (1, 0),
+        test_with_2: (2, 1),
+        test_with_3: (3, 1),
+        test_with_4: (4, 1+2),
+        test_with_5: (5, 1),
+        test_with_6: (6, 6),
+        test_with_15: (15, 9),
+        test_with_343: (343, 57),
     }
 
     #[test]

--- a/src/math/aliquot_sum.rs
+++ b/src/math/aliquot_sum.rs
@@ -29,6 +29,7 @@ mod tests {
         )*
         }
     }
+
     test_aliquot_sum! {
         test_with_1: (1, 0),
         test_with_2: (2, 1),


### PR DESCRIPTION
# Pull Request Template

## Description

Please note that the [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum) is not really defined for `0`. This PR:
- changes the implementation to `panic` in case of `0` as input,
- adds missing test cases (they were verified with [A001065](https://oeis.org/A001065)),
- simplified the implementation by removing one branch and making it _more functional_,
- expresses the tests as _parametrized_.

## Type of change
## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
