### PR TITLE
Add algorithm to find a number of points in a polygon area #628

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -108,6 +108,7 @@
     * [Graham Scan](https://github.com/TheAlgorithms/Rust/blob/master/src/geometry/graham_scan.rs)
     * [Jarvis Scan](https://github.com/TheAlgorithms/Rust/blob/master/src/geometry/jarvis_scan.rs)
     * [Point](https://github.com/TheAlgorithms/Rust/blob/master/src/geometry/point.rs)
+    * [Polygon Points](https://github.com/TheAlgorithms/Rust/blob/master/src/geometry/polygon_points.rs)
     * [Segment](https://github.com/TheAlgorithms/Rust/blob/master/src/geometry/segment.rs)
   * Graph
     * [Astar](https://github.com/TheAlgorithms/Rust/blob/master/src/graph/astar.rs)

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -3,9 +3,11 @@ mod graham_scan;
 mod jarvis_scan;
 mod point;
 mod segment;
+mod polygon_points;
 
 pub use self::closest_points::closest_points;
 pub use self::graham_scan::graham_scan;
 pub use self::jarvis_scan::jarvis_march;
 pub use self::point::Point;
 pub use self::segment::Segment;
+pub use self::polygon_points::lattice_points;

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -2,12 +2,12 @@ mod closest_points;
 mod graham_scan;
 mod jarvis_scan;
 mod point;
-mod segment;
 mod polygon_points;
+mod segment;
 
 pub use self::closest_points::closest_points;
 pub use self::graham_scan::graham_scan;
 pub use self::jarvis_scan::jarvis_march;
 pub use self::point::Point;
-pub use self::segment::Segment;
 pub use self::polygon_points::lattice_points;
+pub use self::segment::Segment;

--- a/src/geometry/polygon_points.rs
+++ b/src/geometry/polygon_points.rs
@@ -40,9 +40,7 @@ fn boundary(pts: &Vec<Pll>) -> Ll {
 pub fn lattice_points(pts: &Vec<Pll>) -> Ll {
     let bounds = boundary(pts);
     let area = polygon_area(pts);
-    let inside = area + 1 - bounds / 2;
-
-    inside
+    area + 1 - bounds / 2
 }
 
 #[cfg(test)]

--- a/src/geometry/polygon_points.rs
+++ b/src/geometry/polygon_points.rs
@@ -1,0 +1,86 @@
+type Ll = i64;
+type Pll = (Ll, Ll);
+
+fn cross(x1: Ll, y1: Ll, x2: Ll, y2: Ll) -> Ll {
+    x1 * y2 - x2 * y1
+}
+
+pub fn polygon_area(pts: &Vec<Pll>) -> Ll {
+    let mut ats = 0;
+    for i in 2..pts.len() {
+        ats += cross(
+            pts[i].0 - pts[0].0,
+            pts[i].1 - pts[0].1,
+            pts[i - 1].0 - pts[0].0,
+            pts[i - 1].1 - pts[0].1,
+        );
+    }
+    Ll::abs(ats / 2)
+}
+
+fn gcd(mut a: Ll, mut b: Ll) -> Ll {
+    while b != 0 {
+        let temp = b;
+        b = a % b;
+        a = temp;
+    }
+    a
+}
+
+fn boundary(pts: &Vec<Pll>) -> Ll {
+    let mut ats = pts.len() as Ll;
+    for i in 0..pts.len() {
+        let deltax = pts[i].0 - pts[(i + 1) % pts.len()].0;
+        let deltay = pts[i].1 - pts[(i + 1) % pts.len()].1;
+        ats += Ll::abs(gcd(deltax, deltay)) - 1;
+    }
+    ats
+}
+
+pub fn lattice_points(pts: &Vec<Pll>) -> Ll {
+    let bounds = boundary(pts);
+    let area = polygon_area(pts);
+    let inside = area + 1 - bounds / 2;
+
+    inside
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_cross() {
+        assert_eq!(cross(1, 2, 3, 4), 1 * 4 - 3 * 2);
+    }
+
+    #[test]
+    fn test_polygon_3_coordinates() {
+        let pts = vec![(0, 0), (0, 3), (4, 0)];
+        assert_eq!(polygon_area(&pts), 6);
+    }
+
+    #[test]
+    fn test_polygon_4_coordinates() {
+        let pts = vec![(0, 0), (0, 2), (2, 2), (2, 0)];
+        assert_eq!(polygon_area(&pts), 4);
+    }
+
+    #[test]
+    fn test_gcd_multiple_of_common_factor() {
+        assert_eq!(gcd(14, 28), 14);
+    }
+
+    #[test]
+    fn test_boundary() {
+        let pts = vec![(0, 0), (0, 3), (0, 4), (2, 2)];
+        assert_eq!(boundary(&pts), 8);
+    }
+
+    #[test]
+    fn test_lattice_points() {
+        let pts = vec![(1, 1), (5, 1), (5, 4)];
+        let result = lattice_points(&pts);
+        assert_eq!(result, 3);
+    }
+}

--- a/src/geometry/polygon_points.rs
+++ b/src/geometry/polygon_points.rs
@@ -49,7 +49,7 @@ mod tests {
 
     #[test]
     fn test_calculate_cross() {
-        assert_eq!(cross(1, 2, 3, 4), 1 * 4 - 3 * 2);
+        assert_eq!(cross(1, 2, 3, 4), 4 - 3 * 2);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Implemented an algorithm to find a number of points in a polygon area
References:
https://github.com/edsomjr/TEP/blob/master/Geometria_Computacional/slides/poligonos_trelicas/poligonos_trelicas.pdf

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
