### PR TITLE
Handle nonpositive inputs in `trial_division`

### DIFF
--- a/src/math/trial_division.rs
+++ b/src/math/trial_division.rs
@@ -8,7 +8,14 @@ fn double_to_int(amount: f64) -> i128 {
 }
 
 pub fn trial_division(mut num: i128) -> Vec<i128> {
+    if num < 0 {
+        return trial_division(-num);
+    }
     let mut result: Vec<i128> = vec![];
+
+    if num == 0 {
+        return result;
+    }
 
     while num % 2 == 0 {
         result.push(2);
@@ -39,7 +46,10 @@ mod tests {
 
     #[test]
     fn basic() {
+        assert_eq!(trial_division(0), vec![]);
+        assert_eq!(trial_division(1), vec![]);
         assert_eq!(trial_division(9), vec!(3, 3));
+        assert_eq!(trial_division(-9), vec!(3, 3));
         assert_eq!(trial_division(10), vec!(2, 5));
         assert_eq!(trial_division(11), vec!(11));
         assert_eq!(trial_division(33), vec!(3, 11));


### PR DESCRIPTION
## Description

[`trial_division`](https://github.com/TheAlgorithms/Rust/blob/cefe1dc4171a69fc75f5eba9f42cb843344e6938/src/math/trial_division.rs#L10) does not handle properly negative inputs and loops for ever for `0`. This PR fixes that and adds a missing test case.

Please note that `trial_division(0)` will return an _empty vector_ - it fits to the agreement that `trial_division(n)` returns all of the numbers between `2` and `|n-1|` dividing `n`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
