### PR TITLE
LinkedList: make `get` sound

### DIFF
--- a/src/data_structures/linked_list.rs
+++ b/src/data_structures/linked_list.rs
@@ -183,15 +183,15 @@ impl<T> LinkedList<T> {
         }
     }
 
-    pub fn get(&mut self, index: i32) -> Option<&'static T> {
-        Self::get_ith_node(self.head, index)
+    pub fn get(&self, index: i32) -> Option<&T> {
+        Self::get_ith_node(self.head, index).map(|ptr| unsafe { &(*ptr.as_ptr()).val })
     }
 
-    fn get_ith_node(node: Option<NonNull<Node<T>>>, index: i32) -> Option<&'static T> {
+    fn get_ith_node(node: Option<NonNull<Node<T>>>, index: i32) -> Option<NonNull<Node<T>>> {
         match node {
             None => None,
             Some(next_ptr) => match index {
-                0 => Some(unsafe { &(*next_ptr.as_ptr()).val }),
+                0 => Some(next_ptr),
                 _ => Self::get_ith_node(unsafe { (*next_ptr.as_ptr()).next }, index - 1),
             },
         }


### PR DESCRIPTION
`LinkedList::get` triggers an obvious use-after-free: it returns `&'static` references into nodes, which may later be dropped.

```rust
pub fn get(&mut self, index: i32) -> Option<&'static T> {
    Self::get_ith_node(self.head, index)
}
```

This PR modifies it to return `&T`, borrowing from `self` such that `delete` cannot be called until the reference is dead. I also changed it to take `&self` rather than `&mut self` so that multiple borrows can be taken out.

This is technically breaking, as uses which kept a reference while modifying the list will no longer compile. This would generally have been unsound though: reasonable uses (eg the unit tests) are unaffected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I ran below commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `CONTRIBUTING.md` and my code follows its guidelines.