### PR TITLE
refactor: enforce nonegative inputs by using `u32` in `lucas_series`

### DIFF
--- a/src/math/lucas_series.rs
+++ b/src/math/lucas_series.rs
@@ -3,10 +3,7 @@
 // Wikipedia Reference  :  https://en.wikipedia.org/wiki/Lucas_number
 // Other References     :  https://the-algorithms.com/algorithm/lucas-series?lang=python
 
-pub fn recursive_lucas_number(n: i32) -> i32 {
-    if n < 0 {
-        panic!("sorry, this function accepts only non-negative integer arguments.");
-    }
+pub fn recursive_lucas_number(n: u32) -> u32 {
     match n {
         0 => 2,
         1 => 1,
@@ -14,10 +11,7 @@ pub fn recursive_lucas_number(n: i32) -> i32 {
     }
 }
 
-pub fn dynamic_lucas_number(n: i32) -> i32 {
-    if n < 0 {
-        panic!("sorry, this functionc accepts only non-negative integer arguments.");
-    }
+pub fn dynamic_lucas_number(n: u32) -> u32 {
     let mut a = 2;
     let mut b = 1;
 

--- a/src/math/lucas_series.rs
+++ b/src/math/lucas_series.rs
@@ -44,6 +44,16 @@ mod tests {
     test_lucas_number! {
         input_0: (0, 2),
         input_1: (1, 1),
+        input_2: (2, 3),
+        input_3: (3, 4),
+        input_4: (4, 7),
+        input_5: (5, 11),
+        input_6: (6, 18),
+        input_7: (7, 29),
+        input_8: (8, 47),
+        input_9: (9, 76),
+        input_10: (10, 123),
+        input_15: (15, 1364),
         input_20: (20, 15127),
         input_25: (25, 167761),
     }

--- a/src/math/lucas_series.rs
+++ b/src/math/lucas_series.rs
@@ -28,19 +28,23 @@ pub fn dynamic_lucas_number(n: u32) -> u32 {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_recursive_lucas_number() {
-        assert_eq!(recursive_lucas_number(1), 1);
-        assert_eq!(recursive_lucas_number(20), 15127);
-        assert_eq!(recursive_lucas_number(0), 2);
-        assert_eq!(recursive_lucas_number(25), 167761);
+    macro_rules! test_lucas_number {
+        ($($name:ident: $inputs:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let (n, expected) = $inputs;
+                assert_eq!(recursive_lucas_number(n), expected);
+                assert_eq!(dynamic_lucas_number(n), expected);
+            }
+        )*
+        }
     }
 
-    #[test]
-    fn test_dynamic_lucas_number() {
-        assert_eq!(dynamic_lucas_number(1), 1);
-        assert_eq!(dynamic_lucas_number(20), 15127);
-        assert_eq!(dynamic_lucas_number(0), 2);
-        assert_eq!(dynamic_lucas_number(25), 167761);
+    test_lucas_number! {
+        input_0: (0, 2),
+        input_1: (1, 1),
+        input_20: (20, 15127),
+        input_25: (25, 167761),
     }
 }


### PR DESCRIPTION
## Description

This PR simplifies the logic in [`lucas_series.rs`](https://github.com/TheAlgorithms/Rust/blob/febdbb6ddc4c4a9482de97a413b4ae5bf0bd7a01/src/math/lucas_series.rs) by changing the input type to `u32`. Thanks to that, the input is nonnegative.

Besides that there were some small cosmetic changes made. New test cases were verified with [oeis:A000032](https://oeis.org/A000032). 

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
