### PR TITLE
fix: use `is_nan`

### DIFF
--- a/src/math/logarithm.rs
+++ b/src/math/logarithm.rs
@@ -60,15 +60,13 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
     fn test_log_zero_base() {
-        assert_eq!(log(0.0, 100.0, 0.00001), f64::NAN);
+        assert!(log(0.0, 100.0, 0.00001).is_nan());
     }
 
     #[test]
-    #[should_panic] // Should panic because can't compare NAN to NAN
     fn test_log_negative_base() {
-        assert_eq!(log(-1.0, 100.0, 0.00001), f64::NAN);
+        assert!(log(-1.0, 100.0, 0.00001).is_nan());
     }
 
     #[test]


### PR DESCRIPTION
## Description

First of all: all the best for the new year (according to Gregorian calendar)!

This PR changes the tests of the [`log`](https://github.com/TheAlgorithms/Rust/blob/ebdc7cc5aef32f365d619024285a4c1448005660/src/math/logarithm.rs#L11) to use [`is_nan`](https://doc.rust-lang.org/std/primitive.f64.html#method.is_nan). This change makes the tests _more direct_ (i.e. we really want to check that `log` returns `nan` and not that rust _panics_ probably due to comparing two `nan`'s.).

@mihaubuhai - please have a look.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.