### PR TITLE
Set correct starting position for high cursor

### DIFF
--- a/src/sorting/quick_sort.rs
+++ b/src/sorting/quick_sort.rs
@@ -3,22 +3,22 @@ use std::cmp::PartialOrd;
 pub fn partition<T: PartialOrd>(arr: &mut [T], lo: usize, hi: usize) -> usize {
     let pivot = hi;
     let mut i = lo;
-    let mut j = hi;
+    let mut j = hi - 1;
 
     loop {
         while arr[i] < arr[pivot] {
             i += 1;
         }
-        while j > 0 && arr[j - 1] > arr[pivot] {
+        while j > 0 && arr[j] > arr[pivot] {
             j -= 1;
         }
-        if j == 0 || i >= j - 1 {
+        if j == 0 || i >= j {
             break;
-        } else if arr[i] == arr[j - 1] {
+        } else if arr[i] == arr[j] {
             i += 1;
             j -= 1;
         } else {
-            arr.swap(i, j - 1);
+            arr.swap(i, j);
         }
     }
     arr.swap(i, pivot);


### PR DESCRIPTION
	modified:   src/sorting/quick_sort.rs


## Description

Set initial high cursor position correctly and remove relative offsets

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [y ] I ran bellow commands using the latest version of **rust nightly**.
- [ y] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [ y] I ran `cargo fmt` just before my last commit.
- [ y] I ran `cargo test` just before my last commit and all tests passed.
- [ n] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [ n] I added my algorithm to `DIRECTORY.md` with the correct link.
- [ y] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
