### PR TITLE
Properly evaluate `GITHUB_ACTOR`

### DIFF
--- a/.github/workflows/directory_workflow.yml
+++ b/.github/workflows/directory_workflow.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Git Specs
         run: |
           git config --global user.name github-actions
-          git config --global user.email '${GITHUB_ACTOR}@users.noreply.github.com'
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
       - name: Update DIRECTORY.md
         run: |

--- a/.github/workflows/directory_workflow.yml
+++ b/.github/workflows/directory_workflow.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v4
       - name: Setup Git Specs
         run: |
-          git config --global user.name github-actions
+          git config --global user.name "$GITHUB_ACTOR"
           git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
       - name: Update DIRECTORY.md


### PR DESCRIPTION
## Description

`git log` contains records like:
```
commit 88946160a3ee9a7770af607162ac8d69b93849a2
Author: github-actions <${GITHUB_ACTOR}@users.noreply.github.com>
Date:   Tue Jan 2 10:52:28 2024 +0000

    Update DIRECTORY.md [skip actions]
```

This PR _properly evaluates_ the [`GITHUB_ACTOR` variable](https://docs.github.com/en/actions/learn-github-actions/variables) in the respective workflow. When this will be merged, I will create similar PR in other repos.

## Something to consider

Since `user.email` is generated using `GITHUB_ACTOR`, should also `user.name` be set to `GITHUB_ACTOR`?

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
