### PR TITLE
word_break.rs in dynamic_programming

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -90,6 +90,7 @@
     * [Rod Cutting](https://github.com/TheAlgorithms/Rust/blob/master/src/dynamic_programming/rod_cutting.rs)
     * [Snail](https://github.com/TheAlgorithms/Rust/blob/master/src/dynamic_programming/snail.rs)
     * [Subset Generation](https://github.com/TheAlgorithms/Rust/blob/master/src/dynamic_programming/subset_generation.rs)
+    * [Word Break](https://github.com/TheAlgorithms/Rust/blob/master/src/dynamic_programming/word_break.rs)
   * General
     * [Convex Hull](https://github.com/TheAlgorithms/Rust/blob/master/src/general/convex_hull.rs)
     * [Fisher Yates Shuffle](https://github.com/TheAlgorithms/Rust/blob/master/src/general/fisher_yates_shuffle.rs)

--- a/src/dynamic_programming/mod.rs
+++ b/src/dynamic_programming/mod.rs
@@ -15,6 +15,7 @@ mod minimum_cost_path;
 mod rod_cutting;
 mod snail;
 mod subset_generation;
+mod word_break;
 
 pub use self::coin_change::coin_change;
 pub use self::egg_dropping::egg_drop;
@@ -40,3 +41,4 @@ pub use self::minimum_cost_path::minimum_cost_path;
 pub use self::rod_cutting::rod_cut;
 pub use self::snail::snail;
 pub use self::subset_generation::list_subset;
+pub use self::word_break::word_break;

--- a/src/dynamic_programming/word_break.rs
+++ b/src/dynamic_programming/word_break.rs
@@ -26,7 +26,10 @@ impl Trie {
     pub fn insert(&mut self, word: &str) {
         let mut node = self;
         for c in word.chars() {
-            node = node.children.entry(c).or_insert_with(|| Box::new(Trie::new()));
+            node = node
+                .children
+                .entry(c)
+                .or_insert_with(|| Box::new(Trie::new()));
         }
         node.is_word = true;
     }
@@ -58,7 +61,6 @@ impl Trie {
     }
 }
 
-
 pub fn word_break(s: &str, word_dict: Vec<&str>) -> bool {
     let mut trie = Trie::new();
     for word in word_dict {
@@ -76,7 +78,10 @@ mod tests {
     #[test]
     fn typical_cases() {
         assert!(word_break("applepenapple", vec!["apple", "pen"]));
-        assert!(!word_break("catsandog", vec!["cats", "dog", "sand", "and", "cat"]));
+        assert!(!word_break(
+            "catsandog",
+            vec!["cats", "dog", "sand", "and", "cat"]
+        ));
         assert!(word_break("cars", vec!["car", "ca", "rs"]));
     }
 
@@ -105,4 +110,3 @@ mod tests {
         assert!(word_break(&long_string, words));
     }
 }
-

--- a/src/dynamic_programming/word_break.rs
+++ b/src/dynamic_programming/word_break.rs
@@ -9,57 +9,7 @@
 // available words for the current position in the string.
 
 use std::collections::HashMap;
-
-struct Trie {
-    children: HashMap<char, Box<Trie>>,
-    is_word: bool,
-}
-
-impl Trie {
-    pub fn new() -> Self {
-        Trie {
-            children: HashMap::new(),
-            is_word: false,
-        }
-    }
-
-    pub fn insert(&mut self, word: &str) {
-        let mut node = self;
-        for c in word.chars() {
-            node = node
-                .children
-                .entry(c)
-                .or_insert_with(|| Box::new(Trie::new()));
-        }
-        node.is_word = true;
-    }
-
-    pub fn search(&self, s: &str, start: usize, memo: &mut Vec<Option<bool>>) -> bool {
-        if start >= s.len() {
-            return true;
-        }
-
-        if let Some(res) = memo[start] {
-            return res;
-        }
-
-        let mut node = self;
-        for (i, c) in s[start..].chars().enumerate() {
-            if let Some(n) = node.children.get(&c) {
-                node = n;
-                if node.is_word && self.search(s, start + i + 1, memo) {
-                    memo[start] = Some(true);
-                    return true;
-                }
-            } else {
-                break;
-            }
-        }
-
-        memo[start] = Some(false);
-        false
-    }
-}
+use crate::data_structures::Trie; 
 
 pub fn word_break(s: &str, word_dict: Vec<&str>) -> bool {
     let mut trie = Trie::new();

--- a/src/dynamic_programming/word_break.rs
+++ b/src/dynamic_programming/word_break.rs
@@ -8,17 +8,39 @@
 // The Trie will be used to store the words. It will be useful for scanning
 // available words for the current position in the string.
 
+use crate::data_structures::Trie;
 use std::collections::HashMap;
-use crate::data_structures::Trie; 
 
 pub fn word_break(s: &str, word_dict: Vec<&str>) -> bool {
     let mut trie = Trie::new();
     for word in word_dict {
-        trie.insert(word);
+        trie.insert(word.chars(), true);  // Insert each word with a value `true`
     }
 
     let mut memo = vec![None; s.len()];
-    trie.search(s, 0, &mut memo)
+    search(&trie, s, 0, &mut memo)
+}
+
+fn search(trie: &Trie<char, bool>, s: &str, start: usize, memo: &mut Vec<Option<bool>>) -> bool {
+    if start >= s.len() {
+        return true;
+    }
+
+    if let Some(res) = memo[start] {
+        return res;
+    }
+
+    let mut node = trie;
+    for end in start + 1..=s.len() {
+        // Using trie.get to check if a substring is a word
+        if trie.get(s[start..end].chars()).is_some() && search(trie, s, end, memo) {
+            memo[start] = Some(true);
+            return true;
+        }
+    }
+
+    memo[start] = Some(false);
+    false
 }
 
 #[cfg(test)]

--- a/src/dynamic_programming/word_break.rs
+++ b/src/dynamic_programming/word_break.rs
@@ -9,12 +9,11 @@
 // available words for the current position in the string.
 
 use crate::data_structures::Trie;
-use std::collections::HashMap;
 
 pub fn word_break(s: &str, word_dict: Vec<&str>) -> bool {
     let mut trie = Trie::new();
     for word in word_dict {
-        trie.insert(word.chars(), true);  // Insert each word with a value `true`
+        trie.insert(word.chars(), true); // Insert each word with a value `true`
     }
 
     let mut memo = vec![None; s.len()];
@@ -30,7 +29,7 @@ fn search(trie: &Trie<char, bool>, s: &str, start: usize, memo: &mut Vec<Option<
         return res;
     }
 
-    let mut node = trie;
+    let _node = trie;
     for end in start + 1..=s.len() {
         // Using trie.get to check if a substring is a word
         if trie.get(s[start..end].chars()).is_some() && search(trie, s, end, memo) {

--- a/src/dynamic_programming/word_break.rs
+++ b/src/dynamic_programming/word_break.rs
@@ -1,0 +1,108 @@
+// Given a string and a list of words, return true if the string can be
+// segmented into a space-separated sequence of one or more words.
+
+// Note that the same word may be reused
+// multiple times in the segmentation.
+
+// Implementation notes: Trie + Dynamic programming up -> down.
+// The Trie will be used to store the words. It will be useful for scanning
+// available words for the current position in the string.
+
+use std::collections::HashMap;
+
+struct Trie {
+    children: HashMap<char, Box<Trie>>,
+    is_word: bool,
+}
+
+impl Trie {
+    pub fn new() -> Self {
+        Trie {
+            children: HashMap::new(),
+            is_word: false,
+        }
+    }
+
+    pub fn insert(&mut self, word: &str) {
+        let mut node = self;
+        for c in word.chars() {
+            node = node.children.entry(c).or_insert_with(|| Box::new(Trie::new()));
+        }
+        node.is_word = true;
+    }
+
+    pub fn search(&self, s: &str, start: usize, memo: &mut Vec<Option<bool>>) -> bool {
+        if start >= s.len() {
+            return true;
+        }
+
+        if let Some(res) = memo[start] {
+            return res;
+        }
+
+        let mut node = self;
+        for (i, c) in s[start..].chars().enumerate() {
+            if let Some(n) = node.children.get(&c) {
+                node = n;
+                if node.is_word && self.search(s, start + i + 1, memo) {
+                    memo[start] = Some(true);
+                    return true;
+                }
+            } else {
+                break;
+            }
+        }
+
+        memo[start] = Some(false);
+        false
+    }
+}
+
+
+pub fn word_break(s: &str, word_dict: Vec<&str>) -> bool {
+    let mut trie = Trie::new();
+    for word in word_dict {
+        trie.insert(word);
+    }
+
+    let mut memo = vec![None; s.len()];
+    trie.search(s, 0, &mut memo)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::word_break;
+
+    #[test]
+    fn typical_cases() {
+        assert!(word_break("applepenapple", vec!["apple", "pen"]));
+        assert!(!word_break("catsandog", vec!["cats", "dog", "sand", "and", "cat"]));
+        assert!(word_break("cars", vec!["car", "ca", "rs"]));
+    }
+
+    #[test]
+    fn edge_cases() {
+        assert!(!word_break("abc", vec![]));
+        assert!(word_break("a", vec!["a"]));
+    }
+
+    #[test]
+    fn repeated_words() {
+        assert!(word_break("aabb", vec!["a", "b"]));
+        assert!(word_break("aaaaaaa", vec!["a", "aa", "aaa"]));
+    }
+
+    #[test]
+    fn no_solution() {
+        assert!(!word_break("abcdef", vec!["ab", "abc", "cd"]));
+        assert!(!word_break("xyz", vec!["a", "b", "c"]));
+    }
+
+    #[test]
+    fn long_string() {
+        let long_string = "a".repeat(100);
+        let words = vec!["a", "aa", "aaa", "aaaa"];
+        assert!(word_break(&long_string, words));
+    }
+}
+


### PR DESCRIPTION
# Word Break

## Description

This implementation introduces the "Word Break" functionality, a feature that determines whether a given string can be segmented into a sequence of one or more words from a provided list. The solution uses a combination of Trie data structure and dynamic programming, offering efficient word lookup and optimal substructure for segmentation checks.

The algorithm involves building a Trie from the list of words, which allows for fast and efficient prefix searches. With the Trie, we can efficiently scan the string for available words starting from each position. Dynamic programming is then employed to remember and reuse the results of sub-problems, reducing redundant computations.

This method is particularly useful in natural language processing and word parsing scenarios, where such segmentation checks are frequent.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I ran bellow commands using the latest version of **rust nightly**.
- [X] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [X] I ran `cargo fmt` just before my last commit.
- [X] I ran `cargo test` just before my last commit and all tests passed.
- [X] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [X] I added my algorithm to `DIRECTORY.md` with the correct link.
- [X] I checked `COUNTRIBUTING.md` and my code follows its guidelines.