### PR TITLE
Cleanup `perfect_cube.rs`

### DIFF
--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -134,7 +134,7 @@ pub use self::modular_exponential::{mod_inverse, modular_exponential};
 pub use self::newton_raphson::find_root;
 pub use self::nthprime::nthprime;
 pub use self::pascal_triangle::pascal_triangle;
-pub use self::perfect_cube::{perfect_cube, perfect_cube_binary_search};
+pub use self::perfect_cube::perfect_cube_binary_search;
 pub use self::perfect_numbers::perfect_numbers;
 pub use self::perfect_square::perfect_square;
 pub use self::perfect_square::perfect_square_binary_search;

--- a/src/math/perfect_cube.rs
+++ b/src/math/perfect_cube.rs
@@ -1,15 +1,8 @@
-pub fn perfect_cube(n: i32) -> bool {
-    // Calculate the cube root using floating-point arithmetic.
-    let val = (n as f64).powf(1.0 / 3.0);
-    // Check if the cube of the cube root equals the original number.
-    (val * val * val) == (n as f64)
-}
-
 // Check if a number is a perfect cube using binary search.
 pub fn perfect_cube_binary_search(n: i64) -> bool {
     // Handle negative numbers, as cube roots are not defined for negatives.
     if n < 0 {
-        return false;
+        return perfect_cube_binary_search(-n);
     }
 
     // Initialize left and right boundaries for binary search.
@@ -39,17 +32,31 @@ pub fn perfect_cube_binary_search(n: i64) -> bool {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_perfect_cube() {
-        assert!(perfect_cube_binary_search(27));
-        assert!(!perfect_cube_binary_search(4));
+    macro_rules! test_perfect_cube {
+        ($($name:ident: $inputs:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let (n, expected) = $inputs;
+                assert_eq!(perfect_cube_binary_search(n), expected);
+                assert_eq!(perfect_cube_binary_search(-n), expected);
+            }
+        )*
+        }
     }
 
-    #[test]
-    fn test_perfect_cube_binary_search() {
-        assert!(perfect_cube_binary_search(27));
-        assert!(perfect_cube_binary_search(64));
-        assert!(!perfect_cube_binary_search(4));
-        assert!(!perfect_cube_binary_search(-8));
+    test_perfect_cube! {
+        num_0_a_perfect_cube: (0, true),
+        num_1_is_a_perfect_cube: (1, true),
+        num_27_is_a_perfect_cube: (27, true),
+        num_64_is_a_perfect_cube: (64, true),
+        num_8_is_a_perfect_cube: (8, true),
+        num_2_is_not_a_perfect_cube: (2, false),
+        num_3_is_not_a_perfect_cube: (3, false),
+        num_4_is_not_a_perfect_cube: (4, false),
+        num_5_is_not_a_perfect_cube: (5, false),
+        num_999_is_not_a_perfect_cube: (999, false),
+        num_1000_is_a_perfect_cube: (1000, true),
+        num_1001_is_not_a_perfect_cube: (1001, false),
     }
 }

--- a/src/math/perfect_cube.rs
+++ b/src/math/perfect_cube.rs
@@ -1,6 +1,5 @@
 // Check if a number is a perfect cube using binary search.
 pub fn perfect_cube_binary_search(n: i64) -> bool {
-    // Handle negative numbers, as cube roots are not defined for negatives.
     if n < 0 {
         return perfect_cube_binary_search(-n);
     }


### PR DESCRIPTION
## Description
There are few problems with [`perfect_cube.rs`](https://github.com/TheAlgorithms/Rust/blob/cb3b21d81a0e97e4394cbb81db879d4e3f18f762/src/math/perfect_cube.rs):
- the [`perfect_cube`](https://github.com/TheAlgorithms/Rust/blob/cb3b21d81a0e97e4394cbb81db879d4e3f18f762/src/math/perfect_cube.rs#L1) is not tested (note the _typo_ in the [`test_perfect_cube`](https://github.com/TheAlgorithms/Rust/blob/cb3b21d81a0e97e4394cbb81db879d4e3f18f762/src/math/perfect_cube.rs#L43)),
- [`perfect_cube`](https://github.com/TheAlgorithms/Rust/blob/cb3b21d81a0e97e4394cbb81db879d4e3f18f762/src/math/perfect_cube.rs#L1) and [`perfect_cube_binary_search`](https://github.com/TheAlgorithms/Rust/blob/cb3b21d81a0e97e4394cbb81db879d4e3f18f762/src/math/perfect_cube.rs#L9) should have the same input type,
- [`perfect_cube`](https://github.com/TheAlgorithms/Rust/blob/cb3b21d81a0e97e4394cbb81db879d4e3f18f762/src/math/perfect_cube.rs#L1) does not give the correct result for `64 = 4*4*4`,
- I do not see any reason why to exclude negative numbers from being _perfect cubes_. For example `-8 = (-2)*(-2)*(-2)`, so why `-8` is not a _perfect cube_ [here](https://github.com/TheAlgorithms/Rust/blob/cb3b21d81a0e97e4394cbb81db879d4e3f18f762/src/math/perfect_cube.rs#L53)?

This PR fixes above issues by removing `perfect_cube` function and reorganizes the tests. 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I ~added my~ removed algorithm ~to~ from the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
