### PR TITLE
chore: update `codecov/codecov-action` to `v4`

### DIFF
--- a/.github/workflows/upload_coverage_report.yml
+++ b/.github/workflows/upload_coverage_report.yml
@@ -27,9 +27,17 @@ jobs:
           --workspace
           --lcov
           --output-path "${{ env.REPORT_NAME }}"
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload coverage to codecov (tokenless)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: codecov/codecov-action@v4
         with:
+          files: "${{ env.REPORT_NAME }}"
+          fail_ci_if_error: true
+      - name: Upload coverage to codecov (with token)
+        if: "! github.event.pull_request.head.repo.fork "
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: "${{ env.REPORT_NAME }}"
           fail_ci_if_error: true
 ...


### PR DESCRIPTION
## Description

_Toneless_ uploads to codecov are no longer supported. This PR updates `codecov/codecov-action` to `v4` and changes the upload workflow in such a way that:
- tokenless upload it used for PRs created from forks,
- upload with token is used for _every other occasion_.

Before merge: please make sure to add the token as `CODECOV_TOKEN` into the repo secrets. ([**Token was added**](https://github.com/TheAlgorithms/Rust/pull/670#discussion_r1475604128))

It seems that both of the branches work:
- [_tokenless_](https://github.com/TheAlgorithms/Rust/actions/runs/7747641995/job/21129088830),
- [without token](https://github.com/vil02/Rust/actions/runs/7747823368/job/21129141293) - the job has failed due to the lack of the token in my fork, but the branch was correctly selected.