### PR TITLE
Assign value directly for newly created node in `BinarySearchTree::insert`.

### DIFF
--- a/src/data_structures/binary_search_tree.rs
+++ b/src/data_structures/binary_search_tree.rs
@@ -88,7 +88,7 @@ where
                         }
                         None => {
                             let mut node = BinarySearchTree::new();
-                            node.insert(value);
+                            node.value = Some(value);
                             *target_node = Some(Box::new(node));
                         }
                     }


### PR DESCRIPTION
## Description
Not sure if it's a too tiny pick. Change the tree node value assignment to be inline.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I ran bellow commands using the latest version of **rust nightly**.
- [X] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [X] I ran `cargo fmt` just before my last commit.
- [X] I ran `cargo test` just before my last commit and all tests passed.
- [ ] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [ ] I added my algorithm to `DIRECTORY.md` with the correct link.
- [X] I checked `COUNTRIBUTING.md` and my code follows its guidelines.