### PR TITLE
style: remove new warnings from clippy

### DIFF
--- a/src/sorting/wiggle_sort.rs
+++ b/src/sorting/wiggle_sort.rs
@@ -32,7 +32,7 @@ mod tests {
     use super::*;
     use crate::sorting::have_same_elements;
 
-    fn is_wiggle_sorted(nums: &Vec<i32>) -> bool {
+    fn is_wiggle_sorted(nums: &[i32]) -> bool {
         if nums.is_empty() {
             return true;
         }


### PR DESCRIPTION
## Description

While working on #675, I have noticed that there are some [new warnings from clippy](https://github.com/TheAlgorithms/Rust/actions/runs/7892867806/job/21540299324?pr=675). This PR fixes them.
