### PR TITLE
Optimise `quick_sort`

### DIFF
--- a/src/sorting/quick_sort.rs
+++ b/src/sorting/quick_sort.rs
@@ -1,5 +1,3 @@
-use std::cmp::PartialOrd;
-
 pub fn partition<T: PartialOrd>(arr: &mut [T], lo: usize, hi: usize) -> usize {
     let pivot = hi;
     let mut i = lo;
@@ -25,13 +23,19 @@ pub fn partition<T: PartialOrd>(arr: &mut [T], lo: usize, hi: usize) -> usize {
     i
 }
 
-fn _quick_sort<T: Ord>(arr: &mut [T], lo: usize, hi: usize) {
-    if lo < hi {
-        let p = partition(arr, lo, hi);
-        if p > 0 {
-            _quick_sort(arr, lo, p - 1);
+fn _quick_sort<T: Ord>(arr: &mut [T], mut lo: usize, mut hi: usize) {
+    while lo < hi {
+        let pivot = partition(arr, lo, hi);
+
+        if pivot - lo < hi - pivot {
+            if pivot > 0 {
+                _quick_sort(arr, lo, pivot - 1);
+            }
+            lo = pivot + 1;
+        } else {
+            _quick_sort(arr, pivot + 1, hi);
+            hi = pivot - 1;
         }
-        _quick_sort(arr, p + 1, hi);
     }
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description

If the input array is completely ordered, let's say the length of the subarray in the recursion is `m`, each partition operation will result in a left subarray of length `0` and a right subarray of length `m - 1`. In this scenario, the height of the recursion tree will reach `n - 1`, requiring `O(n)` size of stack space.

To avoid this, it's possible to compare the lengths of the two subarrays each time and only recurse on the shorter subarray. Since the length of the shorter subarray won't exceed `n / 2`, this approach ensures that the recursion depth does not go beyond `log(n)`, thereby optimizing **the worst-case** space complexity to `log(n)`.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.