### PR TITLE
Handle unicode characters in `duval_algorithm`

### DIFF
--- a/src/string/duval_algorithm.rs
+++ b/src/string/duval_algorithm.rs
@@ -1,6 +1,6 @@
 // A string is called simple (or a Lyndon word), if it is strictly smaller than any of its own nontrivial suffixes.
 // Duval (1983) developed an algorithm for finding the standard factorization that runs in linear time and constant space. Source: https://en.wikipedia.org/wiki/Lyndon_word
-fn factorization_with_duval(s: &[u8]) -> Vec<String> {
+fn factorization_with_duval(s: Vec<char>) -> Vec<String> {
     let n = s.len();
     let mut i = 0;
     let mut factorization: Vec<String> = Vec::new();
@@ -19,7 +19,7 @@ fn factorization_with_duval(s: &[u8]) -> Vec<String> {
         }
 
         while i <= k {
-            factorization.push(String::from_utf8(s[i..i + j - k].to_vec()).unwrap());
+            factorization.push(s[i..i + j - k].iter().collect::<String>());
             i += j - k;
         }
     }
@@ -28,7 +28,7 @@ fn factorization_with_duval(s: &[u8]) -> Vec<String> {
 }
 
 pub fn duval_algorithm(s: &str) -> Vec<String> {
-    return factorization_with_duval(s.as_bytes());
+    return factorization_with_duval(s.chars().collect::<Vec<char>>());
 }
 
 #[cfg(test)]
@@ -54,10 +54,16 @@ mod test {
     }
 
     #[test]
+    fn test_duval_unicode() {
+        let text = "അഅഅ";
+        assert_eq!(duval_algorithm(text), ["അ", "അ", "അ"]);
+    }
+
+    #[test]
     fn test_factorization_with_duval_multiple() {
         let text = "abcdabcdababc";
         assert_eq!(
-            factorization_with_duval(text.as_bytes()),
+            factorization_with_duval(text.chars().collect::<Vec<char> >()),
             ["abcd", "abcd", "ababc"]
         );
     }

--- a/src/string/duval_algorithm.rs
+++ b/src/string/duval_algorithm.rs
@@ -35,28 +35,23 @@ pub fn duval_algorithm(s: &str) -> Vec<String> {
 mod test {
     use super::*;
 
-    #[test]
-    fn test_duval_multiple() {
-        let text = "abcdabcdababc";
-        assert_eq!(duval_algorithm(text), ["abcd", "abcd", "ababc"]);
+    macro_rules! test_duval_algorithm {
+        ($($name:ident: $inputs:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let (text, expected) = $inputs;
+                assert_eq!(duval_algorithm(text), expected);
+            }
+        )*
+        }
     }
 
-    #[test]
-    fn test_duval_all() {
-        let text = "aaa";
-        assert_eq!(duval_algorithm(text), ["a", "a", "a"]);
-    }
-
-    #[test]
-    fn test_duval_single() {
-        let text = "ababb";
-        assert_eq!(duval_algorithm(text), ["ababb"]);
-    }
-
-    #[test]
-    fn test_duval_unicode() {
-        let text = "അഅഅ";
-        assert_eq!(duval_algorithm(text), ["അ", "അ", "അ"]);
+    test_duval_algorithm! {
+        multiple: ("abcdabcdababc", ["abcd", "abcd", "ababc"]),
+        all: ("aaa", ["a", "a", "a"]),
+        single: ("ababb", ["ababb"]),
+        unicode: ("അഅഅ", ["അ", "അ", "അ"]),
     }
 
     #[test]

--- a/src/string/duval_algorithm.rs
+++ b/src/string/duval_algorithm.rs
@@ -63,7 +63,7 @@ mod test {
     fn test_factorization_with_duval_multiple() {
         let text = "abcdabcdababc";
         assert_eq!(
-            factorization_with_duval(text.chars().collect::<Vec<char> >()),
+            factorization_with_duval(text.chars().collect::<Vec<char>>()),
             ["abcd", "abcd", "ababc"]
         );
     }


### PR DESCRIPTION
Fix duval_algorithm.rs on unicode strings being entered

## Description
I've replaced all instances of &[u8] with its character equivalent and replaced the other instances 
with appropriate substitutes

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [ ] ~I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).~
- [ ] ~I added my algorithm to `DIRECTORY.md` with the correct link.~
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

> note:
> cargo clippy does produce errors but none of them were part of the file I was working on. I'd appreciate it if someone took at look at it