### PR TITLE
feat: Add test to increase coverage of naive permutations

### DIFF
--- a/src/general/permutations/naive.rs
+++ b/src/general/permutations/naive.rs
@@ -99,6 +99,7 @@ mod tests {
     #[test]
     fn empty_array() {
         let empty: std::vec::Vec<u8> = vec![];
+        assert_eq!(permute(&empty), vec![vec![]]);
         assert_eq!(permute_unique(&empty), vec![vec![]]);
     }
 

--- a/src/general/permutations/naive.rs
+++ b/src/general/permutations/naive.rs
@@ -97,6 +97,12 @@ mod tests {
     }
 
     #[test]
+    fn empty_array() {
+        let empty: std::vec::Vec<u8>= vec![];
+        assert_eq!(permute_unique(&empty), vec![vec![]]);
+    }
+
+    #[test]
     fn test_3_times_the_same_value() {
         let original = vec![1, 1, 1];
         let res = permute(&original);

--- a/src/general/permutations/naive.rs
+++ b/src/general/permutations/naive.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn empty_array() {
-        let empty: std::vec::Vec<u8>= vec![];
+        let empty: std::vec::Vec<u8> = vec![];
         assert_eq!(permute_unique(&empty), vec![vec![]]);
     }
 


### PR DESCRIPTION
#  Add a test to cover the empty array case in the naive implementation of permutations

## Description
I've opted for adding a test unsure if this is the right way to go. Do advice for better alternatives
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~New feature (non-breaking change which adds functionality)~
- [ ] ~Breaking change (fix or feature that would cause existing functionality to not work as expected)~

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [ ] ~I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).~
- [ ] ~I added my algorithm to `DIRECTORY.md` with the correct link.~
- [x] I checked `CONTRIBUTING.md` and my code follows its guidelines.