### PR TITLE
fix: suppress clippy warning

### DIFF
--- a/src/data_structures/heap.rs
+++ b/src/data_structures/heap.rs
@@ -156,6 +156,7 @@ mod tests {
         assert_eq!(heap.pop(), Some(2));
     }
 
+    #[allow(dead_code)]
     struct Point(/* x */ i32, /* y */ i32);
 
     #[test]


### PR DESCRIPTION
# Pull Request Template

## Description

One of the [recent jobs](https://github.com/TheAlgorithms/Rust/actions/runs/8481497233/job/23238945730?pr=695#step:3:91) has failed due to some new clippy warning. Basically the problem is that the second coordinate of `Point` defined in:
https://github.com/TheAlgorithms/Rust/blob/1d72d9fa706af87d9e90db91140bcd6d6adc14eb/src/data_structures/heap.rs#L159
is not used.

I am aware of 3 other _fixes_ but they are all not perfect:
- use [`Point`](https://docs.rs/rusttype/latest/rusttype/struct.Point.html#) - might be an overkill in this situation,
- declare the second coordinate as `()` - _strange_,
- mark this structure as `pub` - also _strange_.

So I decided to simply suppress this warning in this line.

@siriak please have a look.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
