### PR TITLE
Update Tim sort implementation

### DIFF
--- a/src/sorting/tim_sort.rs
+++ b/src/sorting/tim_sort.rs
@@ -127,7 +127,37 @@ mod tests {
     use crate::sorting::{have_same_elements, is_sorted};
 
     #[test]
-    fn basic() {
+    fn min_run_length_returns_correct_value() {
+        assert_eq!(min_run_length(0), 0);
+        assert_eq!(min_run_length(10), 10);
+        assert_eq!(min_run_length(33), 17);
+        assert_eq!(min_run_length(64), 16);
+    }
+
+    #[test]
+    fn insertion_sort_sorts_array_correctly() {
+        let mut array = vec![3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5];
+        insertion_sort(&mut array);
+        assert_eq!(array, vec![1, 1, 2, 3, 3, 4, 5, 5, 5, 6, 9]);
+
+        let mut array = vec![1, 2, 3, 4, 5];
+        insertion_sort(&mut array);
+        assert_eq!(array, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn merge_merges_sorted_arrays_correctly() {
+        let mut array = vec![1, 3, 5, 2, 4, 6];
+        merge(&mut array, 0, 2, 5);
+        assert_eq!(array, vec![1, 2, 3, 4, 5, 6]);
+
+        let mut array = vec![1, 2, 3];
+        merge(&mut array, 0, 0, 2);
+        assert_eq!(array, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn tim_sort_sorts_basic_array_correctly() {
         let mut array = vec![-2, 7, 15, -14, 0, 15, 0, 7, -7, -4, -13, 5, 8, -14, 12];
         let cloned = array.clone();
         tim_sort(&mut array);
@@ -135,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn empty() {
+    fn tim_sort_handles_empty_array() {
         let mut array = Vec::<i32>::new();
         let cloned = array.clone();
         tim_sort(&mut array);
@@ -143,7 +173,7 @@ mod tests {
     }
 
     #[test]
-    fn one_element() {
+    fn tim_sort_handles_single_element_array() {
         let mut array = vec![3];
         let cloned = array.clone();
         tim_sort(&mut array);
@@ -151,7 +181,7 @@ mod tests {
     }
 
     #[test]
-    fn pre_sorted() {
+    fn tim_sort_handles_pre_sorted_array() {
         let mut array = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         let cloned = array.clone();
         tim_sort(&mut array);

--- a/src/sorting/tim_sort.rs
+++ b/src/sorting/tim_sort.rs
@@ -141,63 +141,45 @@ mod tests {
         assert_eq!(array, vec![1, 1, 2, 3, 3, 4, 5, 5, 5, 6, 9]);
     }
 
-    #[test]
-    fn merge_left_and_right_subarrays_into_array() {
-        let mut array = vec![0, 2, 4, 1, 3, 5];
-        merge(&mut array, 0, 2, 5);
-        assert_eq!(array, vec![0, 1, 2, 3, 4, 5]);
+    macro_rules! test_merge {
+        ($($name:ident: $inputs:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (input_arr, l, m, r, expected) = $inputs;
+                    let mut arr = input_arr.clone();
+                    merge(&mut arr, l, m, r);
+                    assert_eq!(arr, expected);
+                }
+            )*
+        }
+    }
+    test_merge! {
+        left_and_right_subarrays_into_array: (vec![0, 2, 4, 1, 3, 5], 0, 2, 5, vec![0, 1, 2, 3, 4, 5]),
+        with_empty_left_subarray: (vec![1, 2, 3], 0, 0, 2, vec![1, 2, 3]),
+        with_empty_right_subarray: (vec![1, 2, 3], 0, 2, 2, vec![1, 2, 3]),
+        with_empty_left_and_right_subarrays: (vec![1, 2, 3], 1, 0, 0, vec![1, 2, 3]),
     }
 
-    #[test]
-    fn merge_with_empty_left_subarray() {
-        let mut array = vec![1, 2, 3];
-        merge(&mut array, 0, 0, 2);
-        assert_eq!(array, vec![1, 2, 3]);
+    macro_rules! test_tim_sort {
+        ($($name:ident: $input:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let mut array = $input;
+                    let cloned = array.clone();
+                    tim_sort(&mut array);
+                    assert!(is_sorted(&array) && have_same_elements(&array, &cloned));
+                }
+            )*
+        }
     }
 
-    #[test]
-    fn merge_with_empty_right_subarray() {
-        let mut array = vec![1, 2, 3];
-        merge(&mut array, 0, 2, 2);
-        assert_eq!(array, vec![1, 2, 3]);
-    }
-
-    #[test]
-    fn merge_with_empty_left_and_right_subarrays() {
-        let mut array = vec![1, 2, 3];
-        merge(&mut array, 1, 0, 0);
-        assert_eq!(array, vec![1, 2, 3]);
-    }
-
-    #[test]
-    fn tim_sort_sorts_basic_array_correctly() {
-        let mut array = vec![-2, 7, 15, -14, 0, 15, 0, 7, -7, -4, -13, 5, 8, -14, 12];
-        let cloned = array.clone();
-        tim_sort(&mut array);
-        assert!(is_sorted(&array) && have_same_elements(&array, &cloned));
-    }
-
-    #[test]
-    fn tim_sort_handles_empty_array() {
-        let mut array = Vec::<i32>::new();
-        let cloned = array.clone();
-        tim_sort(&mut array);
-        assert!(is_sorted(&array) && have_same_elements(&array, &cloned));
-    }
-
-    #[test]
-    fn tim_sort_handles_single_element_array() {
-        let mut array = vec![3];
-        let cloned = array.clone();
-        tim_sort(&mut array);
-        assert!(is_sorted(&array) && have_same_elements(&array, &cloned));
-    }
-
-    #[test]
-    fn tim_sort_handles_pre_sorted_array() {
-        let mut array = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let cloned = array.clone();
-        tim_sort(&mut array);
-        assert!(is_sorted(&array) && have_same_elements(&array, &cloned));
+    test_tim_sort! {
+        sorts_basic_array_correctly: vec![-2, 7, 15, -14, 0, 15, 0, 7, -7, -4, -13, 5, 8, -14, 12],
+        sorts_long_array_correctly: vec![-2, 7, 15, -14, 0, 15, 0, 7, -7, -4, -13, 5, 8, -14, 12, 5, 3, 9, 22, 1, 1, 2, 3, 9, 6, 5, 4, 5, 6, 7, 8, 9, 1],
+        handles_empty_array: Vec::<i32>::new(),
+        handles_single_element_array: vec![3],
+        handles_pre_sorted_array: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
     }
 }

--- a/src/sorting/tim_sort.rs
+++ b/src/sorting/tim_sort.rs
@@ -38,7 +38,7 @@ fn min_run_length(mut n: usize) -> usize {
 /// * `l` - The starting index of the first subarray.
 /// * `m` - The ending index of the first subarray.
 /// * `r` - The ending index of the second subarray.
-fn merge(arr: &mut [i32], l: usize, m: usize, r: usize) {
+fn merge<T: Ord + Copy>(arr: &mut [T], l: usize, m: usize, r: usize) {
     let left = arr[l..=m].to_vec();
     let right = arr[m + 1..=r].to_vec();
     let mut i = 0;
@@ -76,7 +76,7 @@ fn merge(arr: &mut [i32], l: usize, m: usize, r: usize) {
 /// # Arguments
 ///
 /// * `arr` - The slice to be sorted.
-pub fn tim_sort(arr: &mut [i32]) {
+pub fn tim_sort<T: Ord + Copy>(arr: &mut [T]) {
     let n = arr.len();
     let min_run = min_run_length(MIN_MERGE);
 
@@ -128,6 +128,7 @@ mod tests {
             )*
         }
     }
+
     test_merge! {
         left_and_right_subarrays_into_array: (vec![0, 2, 4, 1, 3, 5], 0, 2, 5, vec![0, 1, 2, 3, 4, 5]),
         with_empty_left_subarray: (vec![1, 2, 3], 0, 0, 2, vec![1, 2, 3]),

--- a/src/sorting/tim_sort.rs
+++ b/src/sorting/tim_sort.rs
@@ -160,7 +160,7 @@ mod tests {
         let mut array = vec![1, 2, 3];
         merge(&mut array, 0, 2, 2);
         assert_eq!(array, vec![1, 2, 3]);
-    } 
+    }
 
     #[test]
     fn merge_with_empty_left_and_right_subarrays() {

--- a/src/sorting/tim_sort.rs
+++ b/src/sorting/tim_sort.rs
@@ -1,7 +1,23 @@
+//! Implements Tim sort algorithm.
+//!
+//! Tim sort is a hybrid sorting algorithm derived from merge sort and insertion sort.
+//! It is designed to perform well on many kinds of real-world data.
+
 use std::cmp;
 
 static MIN_MERGE: usize = 32;
 
+/// Determines the minimum run length for Tim sort.
+///
+/// The minimum run length is calculated based on the minimum merge size.
+///
+/// # Arguments
+///
+/// * `n` - The length of the array.
+///
+/// # Returns
+///
+/// The minimum run length.
 fn min_run_length(mut n: usize) -> usize {
     let mut r = 0;
     while n >= MIN_MERGE {
@@ -11,37 +27,44 @@ fn min_run_length(mut n: usize) -> usize {
     n + r
 }
 
-fn insertion_sort(arr: &mut Vec<i32>, left: usize, right: usize) -> &Vec<i32> {
-    for i in (left + 1)..(right + 1) {
+/// Sorts a slice using insertion sort algorithm.
+///
+/// This function sorts the provided slice in-place using the insertion sort algorithm.
+///
+/// # Arguments
+///
+/// * `arr` - The slice to be sorted.
+fn insertion_sort(arr: &mut [i32]) {
+    for i in 1..arr.len() {
         let temp = arr[i];
-        let mut j = (i - 1) as i32;
+        let mut j = i;
 
-        while j >= (left as i32) && arr[j as usize] > temp {
-            arr[(j + 1) as usize] = arr[j as usize];
+        while j > 0 && arr[j - 1] > temp {
+            arr[j] = arr[j - 1];
             j -= 1;
         }
-        arr[(j + 1) as usize] = temp;
+        arr[j] = temp;
     }
-    arr
 }
 
-fn merge(arr: &mut Vec<i32>, l: usize, m: usize, r: usize) -> &Vec<i32> {
-    let len1 = m - l + 1;
-    let len2 = r - m;
-    let mut left = vec![0; len1];
-    let mut right = vec![0; len2];
-
-    left[..len1].clone_from_slice(&arr[l..(len1 + l)]);
-
-    for x in 0..len2 {
-        right[x] = arr[m + 1 + x];
-    }
-
+/// Merges two sorted subarrays into a single sorted subarray.
+///
+/// This function merges two sorted subarrays of the provided slice into a single sorted subarray.
+///
+/// # Arguments
+///
+/// * `arr` - The slice containing the subarrays to be merged.
+/// * `l` - The starting index of the first subarray.
+/// * `m` - The ending index of the first subarray.
+/// * `r` - The ending index of the second subarray.
+fn merge(arr: &mut [i32], l: usize, m: usize, r: usize) {
+    let left = arr[l..=m].to_vec();
+    let right = arr[m + 1..=r].to_vec();
     let mut i = 0;
     let mut j = 0;
     let mut k = l;
 
-    while i < len1 && j < len2 {
+    while i < left.len() && j < right.len() {
         if left[i] <= right[j] {
             arr[k] = left[i];
             i += 1;
@@ -52,26 +75,33 @@ fn merge(arr: &mut Vec<i32>, l: usize, m: usize, r: usize) -> &Vec<i32> {
         k += 1;
     }
 
-    while i < len1 {
+    while i < left.len() {
         arr[k] = left[i];
         k += 1;
         i += 1;
     }
 
-    while j < len2 {
+    while j < right.len() {
         arr[k] = right[j];
         k += 1;
         j += 1;
     }
-    arr
 }
 
-pub fn tim_sort(arr: &mut Vec<i32>, n: usize) {
+/// Sorts a slice using Tim sort algorithm.
+///
+/// This function sorts the provided slice in-place using the Tim sort algorithm.
+///
+/// # Arguments
+///
+/// * `arr` - The slice to be sorted.
+pub fn tim_sort(arr: &mut [i32]) {
+    let n = arr.len();
     let min_run = min_run_length(MIN_MERGE);
 
     let mut i = 0;
     while i < n {
-        insertion_sort(arr, i, cmp::min(i + MIN_MERGE - 1, n - 1));
+        insertion_sort(&mut arr[i..cmp::min(i + MIN_MERGE, n)]);
         i += min_run;
     }
 
@@ -94,15 +124,13 @@ pub fn tim_sort(arr: &mut Vec<i32>, n: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sorting::have_same_elements;
-    use crate::sorting::is_sorted;
+    use crate::sorting::{have_same_elements, is_sorted};
 
     #[test]
     fn basic() {
         let mut array = vec![-2, 7, 15, -14, 0, 15, 0, 7, -7, -4, -13, 5, 8, -14, 12];
         let cloned = array.clone();
-        let arr_len = array.len();
-        tim_sort(&mut array, arr_len);
+        tim_sort(&mut array);
         assert!(is_sorted(&array) && have_same_elements(&array, &cloned));
     }
 
@@ -110,8 +138,7 @@ mod tests {
     fn empty() {
         let mut array = Vec::<i32>::new();
         let cloned = array.clone();
-        let arr_len = array.len();
-        tim_sort(&mut array, arr_len);
+        tim_sort(&mut array);
         assert!(is_sorted(&array) && have_same_elements(&array, &cloned));
     }
 
@@ -119,8 +146,7 @@ mod tests {
     fn one_element() {
         let mut array = vec![3];
         let cloned = array.clone();
-        let arr_len = array.len();
-        tim_sort(&mut array, arr_len);
+        tim_sort(&mut array);
         assert!(is_sorted(&array) && have_same_elements(&array, &cloned));
     }
 
@@ -128,8 +154,7 @@ mod tests {
     fn pre_sorted() {
         let mut array = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
         let cloned = array.clone();
-        let arr_len = array.len();
-        tim_sort(&mut array, arr_len);
+        tim_sort(&mut array);
         assert!(is_sorted(&array) && have_same_elements(&array, &cloned));
     }
 }

--- a/src/sorting/tim_sort.rs
+++ b/src/sorting/tim_sort.rs
@@ -139,20 +139,33 @@ mod tests {
         let mut array = vec![3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5];
         insertion_sort(&mut array);
         assert_eq!(array, vec![1, 1, 2, 3, 3, 4, 5, 5, 5, 6, 9]);
-
-        let mut array = vec![1, 2, 3, 4, 5];
-        insertion_sort(&mut array);
-        assert_eq!(array, vec![1, 2, 3, 4, 5]);
     }
 
     #[test]
-    fn merge_merges_sorted_arrays_correctly() {
-        let mut array = vec![1, 3, 5, 2, 4, 6];
+    fn merge_left_and_right_subarrays_into_array() {
+        let mut array = vec![0, 2, 4, 1, 3, 5];
         merge(&mut array, 0, 2, 5);
-        assert_eq!(array, vec![1, 2, 3, 4, 5, 6]);
+        assert_eq!(array, vec![0, 1, 2, 3, 4, 5]);
+    }
 
+    #[test]
+    fn merge_with_empty_left_subarray() {
         let mut array = vec![1, 2, 3];
         merge(&mut array, 0, 0, 2);
+        assert_eq!(array, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn merge_with_empty_right_subarray() {
+        let mut array = vec![1, 2, 3];
+        merge(&mut array, 0, 2, 2);
+        assert_eq!(array, vec![1, 2, 3]);
+    } 
+
+    #[test]
+    fn merge_with_empty_left_and_right_subarrays() {
+        let mut array = vec![1, 2, 3];
+        merge(&mut array, 1, 0, 0);
         assert_eq!(array, vec![1, 2, 3]);
     }
 

--- a/src/sorting/tim_sort.rs
+++ b/src/sorting/tim_sort.rs
@@ -3,6 +3,7 @@
 //! Tim sort is a hybrid sorting algorithm derived from merge sort and insertion sort.
 //! It is designed to perform well on many kinds of real-world data.
 
+use crate::sorting::insertion_sort;
 use std::cmp;
 
 static MIN_MERGE: usize = 32;
@@ -25,26 +26,6 @@ fn min_run_length(mut n: usize) -> usize {
         n >>= 1;
     }
     n + r
-}
-
-/// Sorts a slice using insertion sort algorithm.
-///
-/// This function sorts the provided slice in-place using the insertion sort algorithm.
-///
-/// # Arguments
-///
-/// * `arr` - The slice to be sorted.
-fn insertion_sort(arr: &mut [i32]) {
-    for i in 1..arr.len() {
-        let temp = arr[i];
-        let mut j = i;
-
-        while j > 0 && arr[j - 1] > temp {
-            arr[j] = arr[j - 1];
-            j -= 1;
-        }
-        arr[j] = temp;
-    }
 }
 
 /// Merges two sorted subarrays into a single sorted subarray.
@@ -132,13 +113,6 @@ mod tests {
         assert_eq!(min_run_length(10), 10);
         assert_eq!(min_run_length(33), 17);
         assert_eq!(min_run_length(64), 16);
-    }
-
-    #[test]
-    fn insertion_sort_sorts_array_correctly() {
-        let mut array = vec![3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5];
-        insertion_sort(&mut array);
-        assert_eq!(array, vec![1, 1, 2, 3, 3, 4, 5, 5, 5, 6, 9]);
     }
 
     macro_rules! test_merge {


### PR DESCRIPTION

## Description

- Insertion Sort and Merge Functions: Changed the return type of both functions to `()` since they directly modify the input slice. Removed unnecessary cloning in the `merge` function.
- Function Naming Convention: Renamed `insertion_sort` and `merge` to follow the `snake_case` naming convention.
- Slicing: Used `slicing (&mut arr[i..cmp::min(i + MIN_MERGE, n)])` directly in the `insertion_sort` function instead of passing indices.
- Add file and function level docstring

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
