### PR TITLE
Implements Ramer-Douglas-Peucker simplification algorithm

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -113,6 +113,7 @@
     * [Jarvis Scan](https://github.com/TheAlgorithms/Rust/blob/master/src/geometry/jarvis_scan.rs)
     * [Point](https://github.com/TheAlgorithms/Rust/blob/master/src/geometry/point.rs)
     * [Polygon Points](https://github.com/TheAlgorithms/Rust/blob/master/src/geometry/polygon_points.rs)
+    * [Ramer-Douglas-Peucker](https://github.com/TheAlgorithms/Rust/blob/master/src/geometry/ramer_douglas_peucker.rs)
     * [Segment](https://github.com/TheAlgorithms/Rust/blob/master/src/geometry/segment.rs)
   * Graph
     * [Astar](https://github.com/TheAlgorithms/Rust/blob/master/src/graph/astar.rs)

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -3,6 +3,7 @@ mod graham_scan;
 mod jarvis_scan;
 mod point;
 mod polygon_points;
+mod ramer_douglas_peucker;
 mod segment;
 
 pub use self::closest_points::closest_points;
@@ -10,4 +11,5 @@ pub use self::graham_scan::graham_scan;
 pub use self::jarvis_scan::jarvis_march;
 pub use self::point::Point;
 pub use self::polygon_points::lattice_points;
+pub use self::ramer_douglas_peucker::ramer_douglas_peucker;
 pub use self::segment::Segment;

--- a/src/geometry/ramer_douglas_peucker.rs
+++ b/src/geometry/ramer_douglas_peucker.rs
@@ -28,7 +28,7 @@ pub fn ramer_douglas_peucker(points: &[Point], epsilon: f64) -> Vec<Point> {
 
 fn perpendicular_distance(p: &Point, a: &Point, b: &Point) -> f64 {
     let num = (b.y - a.y) * p.x - (b.x - a.x) * p.y + b.x * a.y - b.y * a.x;
-    let den = a.euclidean_distance(&b);
+    let den = a.euclidean_distance(b);
     num.abs() / den
 }
 

--- a/src/geometry/ramer_douglas_peucker.rs
+++ b/src/geometry/ramer_douglas_peucker.rs
@@ -1,0 +1,73 @@
+use crate::geometry::Point;
+
+pub fn ramer_douglas_peucker(polygon: &[Point], epsilon: f64) -> Vec<Point> {
+    let mut dmax = 0.0;
+    let mut index = 0;
+    let end = polygon.len() - 1;
+
+    for i in 1..end {
+        let d =
+            perpendicular_distance(polygon[i].clone(), polygon[0].clone(), polygon[end].clone());
+        if d > dmax {
+            index = i;
+            dmax = d;
+        }
+    }
+
+    if dmax > epsilon {
+        let mut results = ramer_douglas_peucker(&Vec::from(&polygon[..=index]), epsilon);
+        results.pop();
+        results.extend(ramer_douglas_peucker(
+            &Vec::from(&polygon[index..]),
+            epsilon,
+        ));
+        results
+    } else {
+        vec![polygon[0].clone(), polygon[end].clone()]
+    }
+}
+
+fn perpendicular_distance(p: Point, a: Point, b: Point) -> f64 {
+    let num = (b.y - a.y) * p.x - (b.x - a.x) * p.y + b.x * a.y - b.y * a.x;
+    let den = a.euclidean_distance(&b);
+    num.abs() / den
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_perpendicular_distance() {
+        let a = Point::new(0.0, 0.0);
+        let b = Point::new(0.0, 3.0);
+        let p = Point::new(4.0, 0.0);
+        assert_eq!(perpendicular_distance(p, a, b), 4.0);
+    }
+
+    #[test]
+    fn test_ramer_douglas_peucker() {
+        // This test doesn't make sense, once you change the epsilon value, the result will change. It is hard to predict the result.
+        let a = Point::new(0.0, 0.0);
+        let b = Point::new(1.0, 0.0);
+        let c = Point::new(2.0, 0.0);
+        let d = Point::new(2.0, 1.0);
+        let e = Point::new(2.0, 2.0);
+        let f = Point::new(1.0, 2.0);
+        let g = Point::new(0.0, 2.0);
+        let h = Point::new(0.0, 1.0);
+        let polygon = vec![
+            a.clone(),
+            b,
+            c.clone(),
+            d,
+            e.clone(),
+            f,
+            g.clone(),
+            h.clone(),
+        ];
+        let epsilon = 0.7;
+        let result = ramer_douglas_peucker(&polygon, epsilon);
+        assert_eq!(result, vec![a, c, e, g, h]);
+    }
+}

--- a/src/geometry/ramer_douglas_peucker.rs
+++ b/src/geometry/ramer_douglas_peucker.rs
@@ -36,16 +36,27 @@ fn perpendicular_distance(p: &Point, a: &Point, b: &Point) -> f64 {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_perpendicular_distance() {
-        let a = Point::new(0.0, 0.0);
-        let b = Point::new(0.0, 3.0);
-        let p = Point::new(4.0, 0.0);
-        assert_eq!(perpendicular_distance(&p, &a, &b), 4.0);
+    macro_rules! test_perpendicular_distance {
+        ($($name:ident: $test_case:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (p, a, b, expected) = $test_case;
+                    assert_eq!(perpendicular_distance(&p, &a, &b), expected);
+                    assert_eq!(perpendicular_distance(&p, &b, &a), expected);
+                }
+            )*
+        };
+    }
+
+    test_perpendicular_distance! {
+        basic: (Point::new(4.0, 0.0), Point::new(0.0, 0.0), Point::new(0.0, 3.0), 4.0),
+        basic_shifted_1: (Point::new(4.0, 1.0), Point::new(0.0, 1.0), Point::new(0.0, 4.0), 4.0),
+        basic_shifted_2: (Point::new(2.0, 1.0), Point::new(-2.0, 1.0), Point::new(-2.0, 4.0), 4.0),
     }
 
     #[test]
-    fn test_ramer_douglas_peucker() {
+    fn test_ramer_douglas_peucker_polygon() {
         let a = Point::new(0.0, 0.0);
         let b = Point::new(1.0, 0.0);
         let c = Point::new(2.0, 0.0);
@@ -70,17 +81,35 @@ mod tests {
     }
 
     #[test]
-    fn test_polygon_chain() {
+    fn test_ramer_douglas_peucker_polygonal_chain() {
         let a = Point::new(0., 0.);
         let b = Point::new(2., 0.5);
         let c = Point::new(3., 3.);
         let d = Point::new(6., 3.);
         let e = Point::new(8., 4.);
 
-        let polygon = vec![a.clone(), b, c, d, e.clone()];
+        let points = vec![a.clone(), b, c, d, e.clone()];
 
         let epsilon = 3.; // The epsilon is quite large, so the result will be a single line
-        let result = ramer_douglas_peucker(&polygon, epsilon);
+        let result = ramer_douglas_peucker(&points, epsilon);
         assert_eq!(result, vec![a, e]);
+    }
+
+    #[test]
+    fn test_less_than_three_points() {
+        let a = Point::new(0., 0.);
+        let b = Point::new(1., 1.);
+
+        let epsilon = 0.1;
+
+        assert_eq!(ramer_douglas_peucker(&[], epsilon), vec![]);
+        assert_eq!(
+            ramer_douglas_peucker(&[a.clone()], epsilon),
+            vec![a.clone()]
+        );
+        assert_eq!(
+            ramer_douglas_peucker(&[a.clone(), b.clone()], epsilon),
+            vec![a, b]
+        );
     }
 }

--- a/src/geometry/ramer_douglas_peucker.rs
+++ b/src/geometry/ramer_douglas_peucker.rs
@@ -1,13 +1,15 @@
 use crate::geometry::Point;
 
-pub fn ramer_douglas_peucker(polygon: &[Point], epsilon: f64) -> Vec<Point> {
+pub fn ramer_douglas_peucker(points: &[Point], epsilon: f64) -> Vec<Point> {
+    if points.len() < 3 {
+        return points.to_vec();
+    }
     let mut dmax = 0.0;
     let mut index = 0;
-    let end = polygon.len() - 1;
+    let end = points.len() - 1;
 
     for i in 1..end {
-        let d =
-            perpendicular_distance(polygon[i].clone(), polygon[0].clone(), polygon[end].clone());
+        let d = perpendicular_distance(&points[i], &points[0], &points[end]);
         if d > dmax {
             index = i;
             dmax = d;
@@ -15,19 +17,19 @@ pub fn ramer_douglas_peucker(polygon: &[Point], epsilon: f64) -> Vec<Point> {
     }
 
     if dmax > epsilon {
-        let mut results = ramer_douglas_peucker(&Vec::from(&polygon[..=index]), epsilon);
+        let mut results = ramer_douglas_peucker(&points[..=index], epsilon);
         results.pop();
         results.extend(ramer_douglas_peucker(
-            &Vec::from(&polygon[index..]),
+            &Vec::from(&points[index..]),
             epsilon,
         ));
         results
     } else {
-        vec![polygon[0].clone(), polygon[end].clone()]
+        vec![points[0].clone(), points[end].clone()]
     }
 }
 
-fn perpendicular_distance(p: Point, a: Point, b: Point) -> f64 {
+fn perpendicular_distance(p: &Point, a: &Point, b: &Point) -> f64 {
     let num = (b.y - a.y) * p.x - (b.x - a.x) * p.y + b.x * a.y - b.y * a.x;
     let den = a.euclidean_distance(&b);
     num.abs() / den
@@ -42,12 +44,11 @@ mod tests {
         let a = Point::new(0.0, 0.0);
         let b = Point::new(0.0, 3.0);
         let p = Point::new(4.0, 0.0);
-        assert_eq!(perpendicular_distance(p, a, b), 4.0);
+        assert_eq!(perpendicular_distance(&p, &a, &b), 4.0);
     }
 
     #[test]
     fn test_ramer_douglas_peucker() {
-        // This test doesn't make sense, once you change the epsilon value, the result will change. It is hard to predict the result.
         let a = Point::new(0.0, 0.0);
         let b = Point::new(1.0, 0.0);
         let c = Point::new(2.0, 0.0);
@@ -69,5 +70,22 @@ mod tests {
         let epsilon = 0.7;
         let result = ramer_douglas_peucker(&polygon, epsilon);
         assert_eq!(result, vec![a, c, e, g, h]);
+    }
+
+    #[test]
+    fn test_polygon_chain() {
+        let a = Point::new(0., 0.);
+        let b = Point::new(2., 0.5);
+        let c = Point::new(3., 3.);
+        let d = Point::new(6., 3.);
+        let e = Point::new(8., 4.);
+
+        let polygon = vec![a.clone(), b, c, d, e.clone()];
+
+        let epsilon = 3.; // The epsilon is quite large, so the result will be a single line
+        let result = ramer_douglas_peucker(&polygon, epsilon);
+        assert_eq!(result, vec![a, e]);
+
+
     }
 }

--- a/src/geometry/ramer_douglas_peucker.rs
+++ b/src/geometry/ramer_douglas_peucker.rs
@@ -19,10 +19,7 @@ pub fn ramer_douglas_peucker(points: &[Point], epsilon: f64) -> Vec<Point> {
     if dmax > epsilon {
         let mut results = ramer_douglas_peucker(&points[..=index], epsilon);
         results.pop();
-        results.extend(ramer_douglas_peucker(
-            &Vec::from(&points[index..]),
-            epsilon,
-        ));
+        results.extend(ramer_douglas_peucker(&Vec::from(&points[index..]), epsilon));
         results
     } else {
         vec![points[0].clone(), points[end].clone()]
@@ -85,7 +82,5 @@ mod tests {
         let epsilon = 3.; // The epsilon is quite large, so the result will be a single line
         let result = ramer_douglas_peucker(&polygon, epsilon);
         assert_eq!(result, vec![a, e]);
-
-
     }
 }

--- a/src/geometry/ramer_douglas_peucker.rs
+++ b/src/geometry/ramer_douglas_peucker.rs
@@ -19,7 +19,7 @@ pub fn ramer_douglas_peucker(points: &[Point], epsilon: f64) -> Vec<Point> {
     if dmax > epsilon {
         let mut results = ramer_douglas_peucker(&points[..=index], epsilon);
         results.pop();
-        results.extend(ramer_douglas_peucker(&Vec::from(&points[index..]), epsilon));
+        results.extend(ramer_douglas_peucker(&points[index..], epsilon));
         results
     } else {
         vec![points[0].clone(), points[end].clone()]


### PR DESCRIPTION
# Pull Request Template

## Description

I implemented the Ramer-Douglas-Peucker algorithm. I use it in a project it works very well. This algorithm allow you to reduce the number of point of a polygon and to keep a maximum of precision.

The test doesn't make a real sesnse, since the results changes with the epsilon value.

- https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm 
- https://fr.wikipedia.org/wiki/Algorithme_de_Douglas-Peucker (FR)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**. => My code doesn't make issues
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
