### PR TITLE
chore: run build each Thursday

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 
-on: pull_request
+'on':
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '51 2 * * 4'
 
 jobs:
   fmt:


### PR DESCRIPTION
# Pull Request Template

## Description

In order to avoid new problems after a clippy update, I suggest to run the build cyclically for example each Thursday. 

Related to #718, but I wanted to keep its scope as small as possible, to have it merged as quick as possible.

The CI will pass with having #718.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
