### PR TITLE
Upgrade to the general kmeans and compare the two existing implementations

### DIFF
--- a/src/general/kmeans.rs
+++ b/src/general/kmeans.rs
@@ -117,6 +117,8 @@ impl_kmeans!(f32);
 #[cfg(test)]
 mod test {
     use self::super::f64::kmeans;
+    use crate::machine_learning::k_means;
+    use rand::random;
 
     #[test]
     fn easy_univariate_clustering() {
@@ -184,5 +186,31 @@ mod test {
 
         let clustering = kmeans(xs, 2, None);
         assert_eq!(clustering.unwrap(), vec![0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
+    }
+
+    /// This test eventually shows that we don't need
+    /// two implementation of k means. `general::kmeans_XXX`
+    /// may the better one according to its generalization on
+    /// **dimension** and **type** compare to `machine_learning::k_means`.
+    #[test]
+    fn compare_two_impl_of_k_means() {
+        let mut data_points_gen: Vec<Vec<f64>> = vec![];
+        let mut data_points: Vec<(f64, f64)> = vec![];
+        let n_points: usize = 1000;
+
+        for _ in 0..n_points {
+            let x: f64 = random::<f64>() * 100.0;
+            let y: f64 = random::<f64>() * 100.0;
+
+            data_points_gen.push(vec![x, y]);
+            data_points.push((x, y));
+        }
+
+        let max_iter = 100;
+
+        assert_eq!(
+            kmeans(data_points_gen, 10, Some(max_iter)),
+            k_means(data_points, 10, max_iter)
+        );
     }
 }

--- a/src/general/kmeans.rs
+++ b/src/general/kmeans.rs
@@ -66,11 +66,11 @@ macro_rules! impl_kmeans {
             /// Assign the N D-dimensional data, `xs`, to `k` clusters using
             /// K-Means clustering, with optional iteration limitation `max_iter`
             pub fn kmeans(
-                xs: Vec<Vec<$kind>>,
+                xs: &Vec<Vec<$kind>>,
                 k: usize,
                 max_iter: Option<i32>,
             ) -> Option<Vec<usize>> {
-                if xs.len() < k {
+                if xs.len() < k || k == 0 {
                     return None;
                 }
 
@@ -132,7 +132,7 @@ mod test {
             vec![1.3],
             vec![1.4],
         ];
-        let clustering = kmeans(xs, 2, None);
+        let clustering = kmeans(&xs, 2, None);
         assert_eq!(clustering.unwrap(), vec![0, 0, 0, 0, 1, 1, 1, 1]);
     }
 
@@ -149,7 +149,7 @@ mod test {
             vec![1.4],
             vec![1.5],
         ];
-        let clustering = kmeans(xs, 2, None);
+        let clustering = kmeans(&xs, 2, None);
         assert_eq!(clustering.unwrap(), vec![0, 0, 0, 0, 1, 1, 1, 1, 1]);
     }
 
@@ -165,7 +165,7 @@ mod test {
             vec![1.3, -1.2],
             vec![1.4, -1.3],
         ];
-        let clustering = kmeans(xs, 2, None);
+        let clustering = kmeans(&xs, 2, None);
         assert_eq!(clustering.unwrap(), vec![0, 0, 0, 0, 1, 1, 1, 1]);
     }
 
@@ -184,8 +184,20 @@ mod test {
             vec![2.6201773, 0.9006588, 2.6774097, 1.8188620, 1.6076493],
         ];
 
-        let clustering = kmeans(xs, 2, None);
+        let clustering = kmeans(&xs, 2, None);
         assert_eq!(clustering.unwrap(), vec![0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        let xs = vec![];
+        let clustering = kmeans(&xs, 0, None);
+        assert_eq!(clustering, None);
+        let clustering = kmeans(&xs, 1234, None);
+        assert_eq!(clustering, None);
+        let xs = vec![vec![1.0], vec![2.0], vec![3.0]];
+        let clustering = kmeans(&xs, 4, None);
+        assert_eq!(clustering, None);
     }
 
     /// This test eventually shows that we don't need
@@ -194,7 +206,7 @@ mod test {
     /// **dimension** and **type** compare to `machine_learning::k_means`.
     #[test]
     fn compare_two_impl_of_k_means() {
-        let mut data_points_gen: Vec<Vec<f64>> = vec![];
+        let mut xs: Vec<Vec<f64>> = vec![];
         let mut data_points: Vec<(f64, f64)> = vec![];
         let n_points: usize = 1000;
 
@@ -202,14 +214,14 @@ mod test {
             let x: f64 = random::<f64>() * 100.0;
             let y: f64 = random::<f64>() * 100.0;
 
-            data_points_gen.push(vec![x, y]);
+            xs.push(vec![x, y]);
             data_points.push((x, y));
         }
 
         let max_iter = 100;
 
         assert_eq!(
-            kmeans(data_points_gen, 10, Some(max_iter)),
+            kmeans(&xs, 10, Some(max_iter)),
             k_means(data_points, 10, max_iter)
         );
     }

--- a/src/machine_learning/k_means.rs
+++ b/src/machine_learning/k_means.rs
@@ -1,5 +1,3 @@
-use rand::prelude::random;
-
 fn get_distance(p1: &(f64, f64), p2: &(f64, f64)) -> f64 {
     let dx: f64 = p1.0 - p2.0;
     let dy: f64 = p1.1 - p2.1;
@@ -7,44 +5,43 @@ fn get_distance(p1: &(f64, f64), p2: &(f64, f64)) -> f64 {
     ((dx * dx) + (dy * dy)).sqrt()
 }
 
-fn find_nearest(data_point: &(f64, f64), centroids: &[(f64, f64)]) -> u32 {
-    let mut cluster: u32 = 0;
+fn find_nearest(data_point: &(f64, f64), centroids: &[(f64, f64)]) -> usize {
+    let mut cluster: usize = 0;
 
     for (i, c) in centroids.iter().enumerate() {
         let d1: f64 = get_distance(data_point, c);
         let d2: f64 = get_distance(data_point, &centroids[cluster as usize]);
 
         if d1 < d2 {
-            cluster = i as u32;
+            cluster = i as usize;
         }
     }
 
     cluster
 }
 
-pub fn k_means(data_points: Vec<(f64, f64)>, n_clusters: usize, max_iter: i32) -> Option<Vec<u32>> {
+pub fn k_means(
+    data_points: Vec<(f64, f64)>,
+    n_clusters: usize,
+    max_iter: i32,
+) -> Option<Vec<usize>> {
     if data_points.len() < n_clusters {
         return None;
     }
 
-    let mut centroids: Vec<(f64, f64)> = Vec::new();
-    let mut labels: Vec<u32> = vec![0; data_points.len()];
-
-    for _ in 0..n_clusters {
-        let x: f64 = random::<f64>();
-        let y: f64 = random::<f64>();
-
-        centroids.push((x, y));
-    }
+    let mut centroids: Vec<(f64, f64)> = (0..n_clusters)
+        .map(|j| data_points[j * data_points.len() / n_clusters].clone())
+        .collect();
+    let mut labels: Vec<usize> = vec![0; data_points.len()];
 
     let mut count_iter: i32 = 0;
 
     while count_iter < max_iter {
         let mut new_centroids_position: Vec<(f64, f64)> = vec![(0.0, 0.0); n_clusters];
-        let mut new_centroids_num: Vec<u32> = vec![0; n_clusters];
+        let mut new_centroids_num: Vec<usize> = vec![0; n_clusters];
 
         for (i, d) in data_points.iter().enumerate() {
-            let nearest_cluster: u32 = find_nearest(d, &centroids);
+            let nearest_cluster: usize = find_nearest(d, &centroids);
             labels[i] = nearest_cluster;
 
             new_centroids_position[nearest_cluster as usize].0 += d.0;
@@ -72,6 +69,7 @@ pub fn k_means(data_points: Vec<(f64, f64)>, n_clusters: usize, max_iter: i32) -
 #[cfg(test)]
 mod test {
     use super::*;
+    use rand::random;
 
     #[test]
     fn test_k_means() {

--- a/src/machine_learning/k_means.rs
+++ b/src/machine_learning/k_means.rs
@@ -10,10 +10,10 @@ fn find_nearest(data_point: &(f64, f64), centroids: &[(f64, f64)]) -> usize {
 
     for (i, c) in centroids.iter().enumerate() {
         let d1: f64 = get_distance(data_point, c);
-        let d2: f64 = get_distance(data_point, &centroids[cluster as usize]);
+        let d2: f64 = get_distance(data_point, &centroids[cluster]);
 
         if d1 < d2 {
-            cluster = i as usize;
+            cluster = i;
         }
     }
 
@@ -30,7 +30,7 @@ pub fn k_means(
     }
 
     let mut centroids: Vec<(f64, f64)> = (0..n_clusters)
-        .map(|j| data_points[j * data_points.len() / n_clusters].clone())
+        .map(|j| data_points[j * data_points.len() / n_clusters])
         .collect();
     let mut labels: Vec<usize> = vec![0; data_points.len()];
 
@@ -44,9 +44,9 @@ pub fn k_means(
             let nearest_cluster: usize = find_nearest(d, &centroids);
             labels[i] = nearest_cluster;
 
-            new_centroids_position[nearest_cluster as usize].0 += d.0;
-            new_centroids_position[nearest_cluster as usize].1 += d.1;
-            new_centroids_num[nearest_cluster as usize] += 1;
+            new_centroids_position[nearest_cluster].0 += d.0;
+            new_centroids_position[nearest_cluster].1 += d.1;
+            new_centroids_num[nearest_cluster] += 1;
         }
 
         for i in 0..centroids.len() {


### PR DESCRIPTION
# Pull Request

## Description

* [Upgrade to general kmeans](https://github.com/TheAlgorithms/Rust/commit/13d4202017dac1aaae03912d636ddba52932d4f9):
  * Refactor to macro
  * Add additional optional argument `max_iter` that determine max iteration
  * Fix typos
* [Compare two equivalent implementations of kmeans](https://github.com/TheAlgorithms/Rust/commit/76c8d40d12db1bea801a4fcab49bb309486e8f74):
  * Tiny refactor on the other implementation: `machine_learning::k_means` so that they share the same initial centroids.
  * Add test bench `compare_two_impl_of_k_means`.
  * The test eventually shows that we don't need two implementations of k means.
  * `general::kmeans_XXX` may the better one according to its generalization on **dimension** and **type** compare to `machine_learning::k_means`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue): shows that one of the implementations is unneeded
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
