### PR TITLE
Fix uninlined format args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ quickcheck_macros = "1.0"
 [features]
 default = ["big-math"]
 big-math = ["dep:num-bigint", "dep:num-traits"]
+
+[lints.clippy]
+uninlined_format_args = "warn"

--- a/src/ciphers/morse_code.rs
+++ b/src/ciphers/morse_code.rs
@@ -172,12 +172,7 @@ mod tests {
     #[test]
     fn decrypt_valid_character_set_invalid_morsecode() {
         let expected = format!(
-            "{}{}{}{} {}",
-            _UNKNOWN_MORSE_CHARACTER,
-            _UNKNOWN_MORSE_CHARACTER,
-            _UNKNOWN_MORSE_CHARACTER,
-            _UNKNOWN_MORSE_CHARACTER,
-            _UNKNOWN_MORSE_CHARACTER,
+            "{_UNKNOWN_MORSE_CHARACTER}{_UNKNOWN_MORSE_CHARACTER}{_UNKNOWN_MORSE_CHARACTER}{_UNKNOWN_MORSE_CHARACTER} {_UNKNOWN_MORSE_CHARACTER}",
         );
 
         let encypted = ".-.-.--.-.-. --------. ..---.-.-. .-.-.--.-.-. / .-.-.--.-.-.".to_string();

--- a/src/conversions/binary_to_hexadecimal.rs
+++ b/src/conversions/binary_to_hexadecimal.rs
@@ -66,7 +66,7 @@ pub fn binary_to_hexadecimal(binary_str: &str) -> String {
     }
 
     if is_negative {
-        format!("-{}", hexadecimal)
+        format!("-{hexadecimal}")
     } else {
         hexadecimal
     }

--- a/src/data_structures/linked_list.rs
+++ b/src/data_structures/linked_list.rs
@@ -241,10 +241,10 @@ mod tests {
         let second_value = 2;
         list.insert_at_tail(1);
         list.insert_at_tail(second_value);
-        println!("Linked List is {}", list);
+        println!("Linked List is {list}");
         match list.get(1) {
             Some(val) => assert_eq!(*val, second_value),
-            None => panic!("Expected to find {} at index 1", second_value),
+            None => panic!("Expected to find {second_value} at index 1"),
         }
     }
     #[test]
@@ -253,10 +253,10 @@ mod tests {
         let second_value = 2;
         list.insert_at_head(1);
         list.insert_at_head(second_value);
-        println!("Linked List is {}", list);
+        println!("Linked List is {list}");
         match list.get(0) {
             Some(val) => assert_eq!(*val, second_value),
-            None => panic!("Expected to find {} at index 0", second_value),
+            None => panic!("Expected to find {second_value} at index 0"),
         }
     }
 
@@ -266,10 +266,10 @@ mod tests {
         let second_value = 2;
         list.insert_at_ith(0, 0);
         list.insert_at_ith(1, second_value);
-        println!("Linked List is {}", list);
+        println!("Linked List is {list}");
         match list.get(1) {
             Some(val) => assert_eq!(*val, second_value),
-            None => panic!("Expected to find {} at index 1", second_value),
+            None => panic!("Expected to find {second_value} at index 1"),
         }
     }
 
@@ -279,10 +279,10 @@ mod tests {
         let second_value = 2;
         list.insert_at_ith(0, 1);
         list.insert_at_ith(0, second_value);
-        println!("Linked List is {}", list);
+        println!("Linked List is {list}");
         match list.get(0) {
             Some(val) => assert_eq!(*val, second_value),
-            None => panic!("Expected to find {} at index 0", second_value),
+            None => panic!("Expected to find {second_value} at index 0"),
         }
     }
 
@@ -294,15 +294,15 @@ mod tests {
         list.insert_at_ith(0, 1);
         list.insert_at_ith(1, second_value);
         list.insert_at_ith(1, third_value);
-        println!("Linked List is {}", list);
+        println!("Linked List is {list}");
         match list.get(1) {
             Some(val) => assert_eq!(*val, third_value),
-            None => panic!("Expected to find {} at index 1", third_value),
+            None => panic!("Expected to find {third_value} at index 1"),
         }
 
         match list.get(2) {
             Some(val) => assert_eq!(*val, second_value),
-            None => panic!("Expected to find {} at index 1", second_value),
+            None => panic!("Expected to find {second_value} at index 1"),
         }
     }
 
@@ -331,7 +331,7 @@ mod tests {
         ] {
             match list.get(i) {
                 Some(val) => assert_eq!(*val, expected),
-                None => panic!("Expected to find {} at index {}", expected, i),
+                None => panic!("Expected to find {expected} at index {i}"),
             }
         }
     }
@@ -379,13 +379,13 @@ mod tests {
         list.insert_at_tail(second_value);
         match list.delete_tail() {
             Some(val) => assert_eq!(val, 2),
-            None => panic!("Expected to remove {} at tail", second_value),
+            None => panic!("Expected to remove {second_value} at tail"),
         }
 
-        println!("Linked List is {}", list);
+        println!("Linked List is {list}");
         match list.get(0) {
             Some(val) => assert_eq!(*val, first_value),
-            None => panic!("Expected to find {} at index 0", first_value),
+            None => panic!("Expected to find {first_value} at index 0"),
         }
     }
 
@@ -398,13 +398,13 @@ mod tests {
         list.insert_at_tail(second_value);
         match list.delete_head() {
             Some(val) => assert_eq!(val, 1),
-            None => panic!("Expected to remove {} at head", first_value),
+            None => panic!("Expected to remove {first_value} at head"),
         }
 
-        println!("Linked List is {}", list);
+        println!("Linked List is {list}");
         match list.get(0) {
             Some(val) => assert_eq!(*val, second_value),
-            None => panic!("Expected to find {} at index 0", second_value),
+            None => panic!("Expected to find {second_value} at index 0"),
         }
     }
 
@@ -417,7 +417,7 @@ mod tests {
         list.insert_at_tail(second_value);
         match list.delete_ith(1) {
             Some(val) => assert_eq!(val, 2),
-            None => panic!("Expected to remove {} at tail", second_value),
+            None => panic!("Expected to remove {second_value} at tail"),
         }
 
         assert_eq!(list.length, 1);
@@ -432,7 +432,7 @@ mod tests {
         list.insert_at_tail(second_value);
         match list.delete_ith(0) {
             Some(val) => assert_eq!(val, 1),
-            None => panic!("Expected to remove {} at tail", first_value),
+            None => panic!("Expected to remove {first_value} at tail"),
         }
 
         assert_eq!(list.length, 1);
@@ -449,12 +449,12 @@ mod tests {
         list.insert_at_tail(third_value);
         match list.delete_ith(1) {
             Some(val) => assert_eq!(val, 2),
-            None => panic!("Expected to remove {} at tail", second_value),
+            None => panic!("Expected to remove {second_value} at tail"),
         }
 
         match list.get(1) {
             Some(val) => assert_eq!(*val, third_value),
-            None => panic!("Expected to find {} at index 1", third_value),
+            None => panic!("Expected to find {third_value} at index 1"),
         }
     }
 
@@ -464,7 +464,7 @@ mod tests {
         list.insert_at_tail(1);
         list.insert_at_tail(2);
         list.insert_at_tail(3);
-        println!("Linked List is {}", list);
+        println!("Linked List is {list}");
         assert_eq!(3, list.length);
     }
 
@@ -474,7 +474,7 @@ mod tests {
         list_str.insert_at_tail("A".to_string());
         list_str.insert_at_tail("B".to_string());
         list_str.insert_at_tail("C".to_string());
-        println!("Linked List is {}", list_str);
+        println!("Linked List is {list_str}");
         assert_eq!(3, list_str.length);
     }
 
@@ -483,7 +483,7 @@ mod tests {
         let mut list = LinkedList::<i32>::new();
         list.insert_at_tail(1);
         list.insert_at_tail(2);
-        println!("Linked List is {}", list);
+        println!("Linked List is {list}");
         let retrived_item = list.get(1);
         assert!(retrived_item.is_some());
         assert_eq!(2, *retrived_item.unwrap());
@@ -494,7 +494,7 @@ mod tests {
         let mut list_str = LinkedList::<String>::new();
         list_str.insert_at_tail("A".to_string());
         list_str.insert_at_tail("B".to_string());
-        println!("Linked List is {}", list_str);
+        println!("Linked List is {list_str}");
         let retrived_item = list_str.get(1);
         assert!(retrived_item.is_some());
         assert_eq!("B", *retrived_item.unwrap());

--- a/src/data_structures/segment_tree_recursive.rs
+++ b/src/data_structures/segment_tree_recursive.rs
@@ -80,12 +80,12 @@ impl<T: Debug + Default + Ord + Copy> SegmentTree<T> {
         target_idx: usize,
         val: T,
     ) {
-        println!("{:?}", element_range);
+        println!("{element_range:?}");
         if element_range.start > target_idx || element_range.end <= target_idx {
             return;
         }
         if element_range.end - element_range.start <= 1 && element_range.start == target_idx {
-            println!("{:?}", element_range);
+            println!("{element_range:?}");
             self.tree[idx] = val;
             return;
         }

--- a/src/general/permutations/mod.rs
+++ b/src/general/permutations/mod.rs
@@ -31,10 +31,7 @@ mod tests {
         }
         for permut_value in permuted {
             let count = indices.get_mut(permut_value).unwrap_or_else(|| {
-                panic!(
-                    "Value {} appears too many times in permutation",
-                    permut_value,
-                )
+                panic!("Value {permut_value} appears too many times in permutation")
             });
             *count -= 1; // use this value
             if *count == 0 {

--- a/src/graph/decremental_connectivity.rs
+++ b/src/graph/decremental_connectivity.rs
@@ -43,10 +43,7 @@ impl DecrementalConnectivity {
 
     pub fn delete(&mut self, u: usize, v: usize) {
         if !self.adjacent[u].contains(&v) || self.component[u] != self.component[v] {
-            panic!(
-                "delete called on the edge ({}, {}) which doesn't exist",
-                u, v
-            );
+            panic!("delete called on the edge ({u}, {v}) which doesn't exist");
         }
 
         self.adjacent[u].remove(&v);
@@ -148,7 +145,7 @@ fn has_cycle(
     visited[node] = true;
     for &neighbour in adjacent[node].iter() {
         if !adjacent[neighbour].contains(&node) {
-            panic!("the given graph does not strictly contain bidirectional edges\n {} -> {} exists, but the other direction does not", node, neighbour);
+            panic!("the given graph does not strictly contain bidirectional edges\n {node} -> {neighbour} exists, but the other direction does not");
         }
         if !visited[neighbour] {
             if has_cycle(adjacent, visited, neighbour, node) {

--- a/src/math/binary_exponentiation.rs
+++ b/src/math/binary_exponentiation.rs
@@ -42,7 +42,7 @@ mod tests {
         // Compute all powers from up to ten, using the standard library as the source of truth.
         for i in 0..10 {
             for j in 0..10 {
-                println!("{}, {}", i, j);
+                println!("{i}, {j}");
                 assert_eq!(binary_exponentiation(i, j), u64::pow(i, j))
             }
         }

--- a/src/math/geometric_series.rs
+++ b/src/math/geometric_series.rs
@@ -20,7 +20,7 @@ mod tests {
 
     fn assert_approx_eq(a: f64, b: f64) {
         let epsilon = 1e-10;
-        assert!((a - b).abs() < epsilon, "Expected {}, found {}", a, b);
+        assert!((a - b).abs() < epsilon, "Expected {a}, found {b}");
     }
 
     #[test]

--- a/src/math/sylvester_sequence.rs
+++ b/src/math/sylvester_sequence.rs
@@ -4,11 +4,7 @@
 // Other References     :  https://the-algorithms.com/algorithm/sylvester-sequence?lang=python
 
 pub fn sylvester(number: i32) -> i128 {
-    assert!(
-        number > 0,
-        "The input value of [n={}] has to be > 0",
-        number
-    );
+    assert!(number > 0, "The input value of [n={number}] has to be > 0");
 
     if number == 1 {
         2

--- a/src/math/trig_functions.rs
+++ b/src/math/trig_functions.rs
@@ -187,7 +187,7 @@ mod tests {
                 }
             };
 
-            assert_eq!(format!("{:.5}", value), format!("{:.5}", expected_result));
+            assert_eq!(format!("{value:.5}"), format!("{:.5}", expected_result));
         }
     }
 

--- a/src/sorting/bingo_sort.rs
+++ b/src/sorting/bingo_sort.rs
@@ -37,7 +37,7 @@ pub fn bingo_sort(vec: &mut [i32]) {
 fn print_array(arr: &[i32]) {
     print!("Sorted Array: ");
     for &element in arr {
-        print!("{} ", element);
+        print!("{element} ");
     }
     println!();
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds [`uninlined_format_args`](https://rust-lang.github.io/rust-clippy/master/#/uninlined_format_args) into the clippy setup.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
