### PR TITLE
chore: add `map_unwrap_or` warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ big-math = ["dep:num-bigint", "dep:num-traits"]
 
 [lints.clippy]
 uninlined_format_args = "warn"
+map_unwrap_or = "warn"

--- a/src/graph/astar.rs
+++ b/src/graph/astar.rs
@@ -62,8 +62,7 @@ pub fn astar<V: Ord + Copy, E: Ord + Copy + Add<Output = E> + Zero>(
             let real_weight = real_weight + weight;
             if weights
                 .get(&next)
-                .map(|&weight| real_weight < weight)
-                .unwrap_or(true)
+                .map_or(true, |&weight| real_weight < weight)
             {
                 // current allows us to reach next with lower weight (or at all)
                 // add next to the front


### PR DESCRIPTION
## Description
This PR adds [`map_unwrap_or`](https://rust-lang.github.io/rust-clippy/v0.0.212/#option_map_unwrap_or) into the clippy setup.

Similar to #738.

[Codecov failuers](https://github.com/TheAlgorithms/Rust/actions/runs/9418711713/job/25947556586?pr=739) are super annoying...

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
