### PR TITLE
style: cleanup `run_length_encoding.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,6 @@ std_instead_of_core = { level = "allow", priority = 1 }
 str_to_string = { level = "allow", priority = 1 }
 string_add = { level = "allow", priority = 1 }
 string_slice = { level = "allow", priority = 1 }
-string_to_string = { level = "allow", priority = 1 }
 undocumented_unsafe_blocks = { level = "allow", priority = 1 }
 unnecessary_safety_comment = { level = "allow", priority = 1 }
 unneeded_field_pattern = { level = "allow", priority = 1 }

--- a/src/string/run_length_encoding.rs
+++ b/src/string/run_length_encoding.rs
@@ -61,52 +61,28 @@ mod tests {
     }
 
     #[test]
-    fn encode_identical_character() {
-        assert_eq!(run_length_encoding("aaaaaaaaaa"), "10a")
-    }
-    #[test]
-    fn encode_continuous_character() {
-        assert_eq!(run_length_encoding("abcdefghijk"), "1a1b1c1d1e1f1g1h1i1j1k")
-    }
-
-    #[test]
-    fn encode_random_character() {
-        assert_eq!(run_length_encoding("aaaaabbbcccccdddddddddd"), "5a3b5c10d")
-    }
-
-    #[test]
-    fn encode_long_character() {
-        assert_eq!(
-            run_length_encoding(
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbcccccdddddddddd"
-            ),
-            "200a3b5c10d"
-        )
-    }
-    #[test]
     fn decode_empty() {
         assert_eq!(run_length_decoding(""), "String is Empty!")
     }
 
-    #[test]
-    fn decode_identical_character() {
-        assert_eq!(run_length_decoding("10a"), "aaaaaaaaaa")
-    }
-    #[test]
-    fn decode_continuous_character() {
-        assert_eq!(run_length_decoding("1a1b1c1d1e1f1g1h1i1j1k"), "abcdefghijk")
+    macro_rules! test_run_length {
+        ($($name:ident: $test_case:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (raw_str, encoded) = $test_case;
+                    assert_eq!(run_length_encoding(raw_str), encoded);
+                    assert_eq!(run_length_decoding(encoded), raw_str);
+                }
+            )*
+        };
     }
 
-    #[test]
-    fn decode_random_character() {
-        assert_eq!(run_length_decoding("5a3b5c10d"), "aaaaabbbcccccdddddddddd")
-    }
-
-    #[test]
-    fn decode_long_character() {
-        assert_eq!(
-            run_length_decoding("200a3b5c10d"),
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbcccccdddddddddd"
-        )
+    test_run_length! {
+        repeated_char: ("aaaaaaaaaa", "10a"),
+        no_repeated: ("abcdefghijk", "1a1b1c1d1e1f1g1h1i1j1k"),
+        regular_input: ("aaaaabbbcccccdddddddddd", "5a3b5c10d"),
+        two_blocks_with_same_char: ("aaabbaaaa", "3a2b4a"),
+        long_input: ("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbcccccdddddddddd", "200a3b5c10d"),
     }
 }

--- a/src/string/run_length_encoding.rs
+++ b/src/string/run_length_encoding.rs
@@ -1,6 +1,6 @@
 pub fn run_length_encoding(target: &str) -> String {
     if target.trim().is_empty() {
-        return "String is Empty!".to_string();
+        return "".to_string();
     }
     let mut count: i32 = 0;
     let mut base_character: String = "".to_string();
@@ -27,9 +27,8 @@ pub fn run_length_encoding(target: &str) -> String {
 
 pub fn run_length_decoding(target: &str) -> String {
     if target.trim().is_empty() {
-        return "String is Empty!".to_string();
+        return "".to_string();
     }
-
     let mut character_count: String = String::new();
     let mut decoded_target = String::new();
 
@@ -55,16 +54,6 @@ pub fn run_length_decoding(target: &str) -> String {
 mod tests {
     use super::*;
 
-    #[test]
-    fn encode_empty() {
-        assert_eq!(run_length_encoding(""), "String is Empty!")
-    }
-
-    #[test]
-    fn decode_empty() {
-        assert_eq!(run_length_decoding(""), "String is Empty!")
-    }
-
     macro_rules! test_run_length {
         ($($name:ident: $test_case:expr,)*) => {
             $(
@@ -79,6 +68,7 @@ mod tests {
     }
 
     test_run_length! {
+        empty_input: ("", ""),
         repeated_char: ("aaaaaaaaaa", "10a"),
         no_repeated: ("abcdefghijk", "1a1b1c1d1e1f1g1h1i1j1k"),
         regular_input: ("aaaaabbbcccccdddddddddd", "5a3b5c10d"),

--- a/src/string/run_length_encoding.rs
+++ b/src/string/run_length_encoding.rs
@@ -99,10 +99,7 @@ mod tests {
 
     #[test]
     fn decode_random_character() {
-        assert_eq!(
-            run_length_decoding("5a3b5c10d").to_string(),
-            "aaaaabbbcccccdddddddddd"
-        )
+        assert_eq!(run_length_decoding("5a3b5c10d"), "aaaaabbbcccccdddddddddd")
     }
 
     #[test]


### PR DESCRIPTION
# Pull Request Template

## Description

This PR cleanups the `run_length_encoding.rs`:
- the `string_to_string` is removed from the suppression list - continuation of #743,
- the tests are rewritten using a macro,
- the way how these functions react to empty input was changed.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
