### PR TITLE
style: include `useless_let_if_seq`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,5 @@ redundant_pub_crate = { level = "allow", priority = 1 }
 suboptimal_flops = { level = "allow", priority = 1 }
 suspicious_operation_groupings = { level = "allow", priority = 1 }
 use_self = { level = "allow", priority = 1 }
-useless_let_if_seq = { level = "allow", priority = 1 }
 # cargo-lints:
 cargo_common_metadata = { level = "allow", priority = 1 }

--- a/src/math/zellers_congruence_algorithm.rs
+++ b/src/math/zellers_congruence_algorithm.rs
@@ -2,12 +2,11 @@
 
 pub fn zellers_congruence_algorithm(date: i32, month: i32, year: i32, as_string: bool) -> String {
     let q = date;
-    let mut m = month;
-    let mut y = year;
-    if month < 3 {
-        m = month + 12;
-        y = year - 1;
-    }
+    let (m, y) = if month < 3 {
+        (month + 12, year - 1)
+    } else {
+        (month, year)
+    };
     let day: i32 =
         (q + (26 * (m + 1) / 10) + (y % 100) + ((y % 100) / 4) + ((y / 100) / 4) + (5 * (y / 100)))
             % 7;

--- a/src/sorting/heap_sort.rs
+++ b/src/sorting/heap_sort.rs
@@ -30,10 +30,11 @@ fn build_heap<T: Ord>(arr: &mut [T], is_max_heap: bool) {
 /// * `i` - The index to start fixing the heap violation.
 /// * `is_max_heap` - A boolean indicating whether to maintain a max heap or a min heap.
 fn heapify<T: Ord>(arr: &mut [T], i: usize, is_max_heap: bool) {
-    let mut comparator: fn(&T, &T) -> Ordering = |a, b| a.cmp(b);
-    if !is_max_heap {
-        comparator = |a, b| b.cmp(a);
-    }
+    let comparator: fn(&T, &T) -> Ordering = if !is_max_heap {
+        |a, b| b.cmp(a)
+    } else {
+        |a, b| a.cmp(b)
+    };
 
     let mut idx = i;
     let l = 2 * i + 1;


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes the [`useless_let_if_seq`](https://rust-lang.github.io/rust-clippy/master/#/useless_let_if_seq) from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
