### PR TITLE
style: include `needless_pass_by_ref_mut`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,6 @@ imprecise_flops = { level = "allow", priority = 1 }
 iter_on_single_items = { level = "allow", priority = 1 }
 missing_const_for_fn = { level = "allow", priority = 1 }
 needless_collect = { level = "allow", priority = 1 }
-needless_pass_by_ref_mut = { level = "allow", priority = 1 }
 nonstandard_macro_braces = { level = "allow", priority = 1 }
 option_if_let_else = { level = "allow", priority = 1 }
 redundant_clone = { level = "allow", priority = 1 }

--- a/src/data_structures/floyds_algorithm.rs
+++ b/src/data_structures/floyds_algorithm.rs
@@ -5,7 +5,7 @@
 
 use crate::data_structures::linked_list::LinkedList; // Import the LinkedList from linked_list.rs
 
-pub fn detect_cycle<T>(linked_list: &mut LinkedList<T>) -> Option<usize> {
+pub fn detect_cycle<T>(linked_list: &LinkedList<T>) -> Option<usize> {
     let mut current = linked_list.head;
     let mut checkpoint = linked_list.head;
     let mut steps_until_reset = 1;
@@ -70,7 +70,7 @@ mod tests {
 
         assert!(!has_cycle(&linked_list));
 
-        assert_eq!(detect_cycle(&mut linked_list), None);
+        assert_eq!(detect_cycle(&linked_list), None);
     }
 
     #[test]
@@ -90,6 +90,6 @@ mod tests {
         }
 
         assert!(has_cycle(&linked_list));
-        assert_eq!(detect_cycle(&mut linked_list), Some(3));
+        assert_eq!(detect_cycle(&linked_list), Some(3));
     }
 }

--- a/src/graph/ford_fulkerson.rs
+++ b/src/graph/ford_fulkerson.rs
@@ -17,7 +17,7 @@ use std::collections::VecDeque;
 
 const V: usize = 6; // Number of vertices in graph
 
-pub fn bfs(r_graph: &mut [Vec<i32>], s: usize, t: usize, parent: &mut [i32]) -> bool {
+pub fn bfs(r_graph: &[Vec<i32>], s: usize, t: usize, parent: &mut [i32]) -> bool {
     let mut visited = [false; V];
     visited[s] = true;
     parent[s] = -1;
@@ -41,12 +41,12 @@ pub fn bfs(r_graph: &mut [Vec<i32>], s: usize, t: usize, parent: &mut [i32]) -> 
     false
 }
 
-pub fn ford_fulkerson(graph: &mut [Vec<i32>], s: usize, t: usize) -> i32 {
+pub fn ford_fulkerson(graph: &[Vec<i32>], s: usize, t: usize) -> i32 {
     let mut r_graph = graph.to_owned();
     let mut parent = vec![-1; V];
     let mut max_flow = 0;
 
-    while bfs(&mut r_graph, s, t, &mut parent) {
+    while bfs(&r_graph, s, t, &mut parent) {
         let mut path_flow = i32::MAX;
         let mut v = t;
 
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn test_example_1() {
-        let mut graph = vec![
+        let graph = vec![
             vec![0, 12, 0, 13, 0, 0],
             vec![0, 0, 10, 0, 0, 0],
             vec![0, 0, 0, 13, 3, 15],
@@ -84,12 +84,12 @@ mod tests {
             vec![0, 0, 6, 0, 0, 17],
             vec![0, 0, 0, 0, 0, 0],
         ];
-        assert_eq!(ford_fulkerson(&mut graph, 0, 5), 23);
+        assert_eq!(ford_fulkerson(&graph, 0, 5), 23);
     }
 
     #[test]
     fn test_example_2() {
-        let mut graph = vec![
+        let graph = vec![
             vec![0, 4, 0, 3, 0, 0],
             vec![0, 0, 4, 0, 8, 0],
             vec![0, 0, 0, 3, 0, 2],
@@ -97,12 +97,12 @@ mod tests {
             vec![0, 0, 6, 0, 0, 6],
             vec![0, 0, 0, 0, 0, 0],
         ];
-        assert_eq!(ford_fulkerson(&mut graph, 0, 5), 7);
+        assert_eq!(ford_fulkerson(&graph, 0, 5), 7);
     }
 
     #[test]
     fn test_example_3() {
-        let mut graph = vec![
+        let graph = vec![
             vec![0, 10, 0, 10, 0, 0],
             vec![0, 0, 4, 2, 8, 0],
             vec![0, 0, 0, 0, 0, 10],
@@ -110,12 +110,12 @@ mod tests {
             vec![0, 0, 6, 0, 0, 10],
             vec![0, 0, 0, 0, 0, 0],
         ];
-        assert_eq!(ford_fulkerson(&mut graph, 0, 5), 19);
+        assert_eq!(ford_fulkerson(&graph, 0, 5), 19);
     }
 
     #[test]
     fn test_example_4() {
-        let mut graph = vec![
+        let graph = vec![
             vec![0, 8, 0, 0, 3, 0],
             vec![0, 0, 9, 0, 0, 0],
             vec![0, 0, 0, 0, 7, 2],
@@ -123,12 +123,12 @@ mod tests {
             vec![0, 0, 7, 4, 0, 0],
             vec![0, 0, 0, 0, 0, 0],
         ];
-        assert_eq!(ford_fulkerson(&mut graph, 0, 5), 6);
+        assert_eq!(ford_fulkerson(&graph, 0, 5), 6);
     }
 
     #[test]
     fn test_example_5() {
-        let mut graph = vec![
+        let graph = vec![
             vec![0, 16, 13, 0, 0, 0],
             vec![0, 0, 10, 12, 0, 0],
             vec![0, 4, 0, 0, 14, 0],
@@ -136,6 +136,6 @@ mod tests {
             vec![0, 0, 0, 7, 0, 4],
             vec![0, 0, 0, 0, 0, 0],
         ];
-        assert_eq!(ford_fulkerson(&mut graph, 0, 5), 23);
+        assert_eq!(ford_fulkerson(&graph, 0, 5), 23);
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`needless_pass_by_ref_mut`](https://rust-lang.github.io/rust-clippy/master/#/needless_pass_by_ref_mut) from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
