### PR TITLE
style: incldue `explicit_into_iter_loop`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ default_trait_access = { level = "allow", priority = 1 }
 doc_markdown = { level = "allow", priority = 1 }
 enum_glob_use = { level = "allow", priority = 1 }
 explicit_deref_methods = { level = "allow", priority = 1 }
-explicit_into_iter_loop = { level = "allow", priority = 1 }
 explicit_iter_loop = { level = "allow", priority = 1 }
 float_cmp = { level = "allow", priority = 1 }
 from_iter_instead_of_collect = { level = "allow", priority = 1 }

--- a/src/big_integer/fast_factorial.rs
+++ b/src/big_integer/fast_factorial.rs
@@ -44,7 +44,7 @@ pub fn fast_factorial(n: usize) -> BigUint {
     a.resize(max_bits as usize, BigUint::one());
 
     // For every prime p, multiply a[i] by p if the ith bit of p's index is 1
-    for (p, i) in p_indeces.into_iter() {
+    for (p, i) in p_indeces {
         let mut bit = 1usize;
         while bit.ilog2() < max_bits {
             if (bit & i) > 0 {

--- a/src/data_structures/trie.rs
+++ b/src/data_structures/trie.rs
@@ -32,7 +32,7 @@ where
         Key: Eq + Hash,
     {
         let mut node = &mut self.root;
-        for c in key.into_iter() {
+        for c in key {
             node = node.children.entry(c).or_default();
         }
         node.value = Some(value);
@@ -43,7 +43,7 @@ where
         Key: Eq + Hash,
     {
         let mut node = &self.root;
-        for c in key.into_iter() {
+        for c in key {
             if node.children.contains_key(&c) {
                 node = node.children.get(&c).unwrap()
             } else {


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`explicit_into_iter_loop`](https://rust-lang.github.io/rust-clippy/master/#/explicit_into_iter_loop) from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
