### PR TITLE
style: include `needless_collect`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,6 @@ fallible_impl_from = { level = "allow", priority = 1 }
 imprecise_flops = { level = "allow", priority = 1 }
 iter_on_single_items = { level = "allow", priority = 1 }
 missing_const_for_fn = { level = "allow", priority = 1 }
-needless_collect = { level = "allow", priority = 1 }
 nonstandard_macro_braces = { level = "allow", priority = 1 }
 option_if_let_else = { level = "allow", priority = 1 }
 redundant_clone = { level = "allow", priority = 1 }

--- a/src/string/autocomplete_using_trie.rs
+++ b/src/string/autocomplete_using_trie.rs
@@ -21,7 +21,7 @@ impl Trie {
     fn insert(&mut self, text: &str) {
         let mut trie = self;
 
-        for c in text.chars().collect::<Vec<char>>() {
+        for c in text.chars() {
             trie = trie.0.entry(c).or_insert_with(|| Box::new(Trie::new()));
         }
 
@@ -31,7 +31,7 @@ impl Trie {
     fn find(&self, prefix: &str) -> Vec<String> {
         let mut trie = self;
 
-        for c in prefix.chars().collect::<Vec<char>>() {
+        for c in prefix.chars() {
             let char_trie = trie.0.get(&c);
             if let Some(char_trie) = char_trie {
                 trie = char_trie;


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`needless_collect`](https://rust-lang.github.io/rust-clippy/master/#/needless_collect) from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
