### PR TITLE
style: include `unnecessary_join`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ stable_sort_primitive = { level = "allow", priority = 1 }
 too_many_lines = { level = "allow", priority = 1 }
 trivially_copy_pass_by_ref = { level = "allow", priority = 1 }
 unnecessary_box_returns = { level = "allow", priority = 1 }
-unnecessary_join = { level = "allow", priority = 1 }
 unnecessary_wraps = { level = "allow", priority = 1 }
 unnested_or_patterns = { level = "allow", priority = 1 }
 unreadable_literal = { level = "allow", priority = 1 }

--- a/src/ciphers/morse_code.rs
+++ b/src/ciphers/morse_code.rs
@@ -96,11 +96,7 @@ fn _decode_token(string: &str) -> String {
 }
 
 fn _decode_part(string: &str) -> String {
-    string
-        .split(' ')
-        .map(_decode_token)
-        .collect::<Vec<String>>()
-        .join("")
+    string.split(' ').map(_decode_token).collect::<String>()
 }
 
 /// Convert morse code to ascii.


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`unnecessary_join`](https://rust-lang.github.io/rust-clippy/master/#/unnecessary_join) from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
