### PR TITLE
style: include `redundant_pub_crate`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,6 @@ missing_const_for_fn = { level = "allow", priority = 1 }
 nonstandard_macro_braces = { level = "allow", priority = 1 }
 option_if_let_else = { level = "allow", priority = 1 }
 redundant_clone = { level = "allow", priority = 1 }
-redundant_pub_crate = { level = "allow", priority = 1 }
 suboptimal_flops = { level = "allow", priority = 1 }
 suspicious_operation_groupings = { level = "allow", priority = 1 }
 use_self = { level = "allow", priority = 1 }

--- a/src/general/permutations/mod.rs
+++ b/src/general/permutations/mod.rs
@@ -11,7 +11,7 @@ mod tests {
     use quickcheck::{Arbitrary, Gen};
     use std::collections::HashMap;
 
-    pub(crate) fn assert_permutations(original: &[i32], permutations: &[Vec<i32>]) {
+    pub fn assert_permutations(original: &[i32], permutations: &[Vec<i32>]) {
         if original.is_empty() {
             assert_eq!(vec![vec![] as Vec<i32>], permutations);
             return;
@@ -23,7 +23,7 @@ mod tests {
         }
     }
 
-    pub(crate) fn assert_valid_permutation(original: &[i32], permuted: &[i32]) {
+    pub fn assert_valid_permutation(original: &[i32], permuted: &[i32]) {
         assert_eq!(original.len(), permuted.len());
         let mut indices = HashMap::with_capacity(original.len());
         for value in original {
@@ -78,7 +78,7 @@ mod tests {
     /// A Data Structure for testing permutations
     /// Holds a Vec<i32> with just a few items, so that it's not too long to compute permutations
     #[derive(Debug, Clone)]
-    pub(crate) struct NotTooBigVec {
+    pub struct NotTooBigVec {
         pub(crate) inner: Vec<i32>, // opaque type alias so that we can implement Arbitrary
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`redundant_pub_crate`](https://rust-lang.github.io/rust-clippy/master/#/redundant_pub_crate) from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
