### PR TITLE
style: suppress some new clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,3 +165,5 @@ suspicious_operation_groupings = { level = "allow", priority = 1 }
 use_self = { level = "allow", priority = 1 }
 # cargo-lints:
 cargo_common_metadata = { level = "allow", priority = 1 }
+# style-lints:
+legacy_numeric_constants = { level = "allow", priority = 1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ impl_trait_in_params = { level = "allow", priority = 1 }
 implicit_return = { level = "allow", priority = 1 }
 indexing_slicing = { level = "allow", priority = 1 }
 integer_division = { level = "allow", priority = 1 }
+integer_division_remainder_used = { level = "allow", priority = 1 }
 iter_over_hash_type = { level = "allow", priority = 1 }
 little_endian_bytes = { level = "allow", priority = 1 }
 map_err_ignore = { level = "allow", priority = 1 }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR _suppresses_ the [`integer_division_remainder_used`](https://rust-lang.github.io/rust-clippy/master/index.html#/integer_division_remainder_used) and [`legacy_numeric_constants`](https://rust-lang.github.io/rust-clippy/master/index.html#/legacy_numeric_constants) lints. It is needed due to [currently failing clippy](https://github.com/TheAlgorithms/Rust/actions/runs/9590879650/job/26446921756).

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
