### PR TITLE
style: include `legacy_numeric_constants`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,5 +165,3 @@ suspicious_operation_groupings = { level = "allow", priority = 1 }
 use_self = { level = "allow", priority = 1 }
 # cargo-lints:
 cargo_common_metadata = { level = "allow", priority = 1 }
-# style-lints:
-legacy_numeric_constants = { level = "allow", priority = 1 }

--- a/src/dynamic_programming/egg_dropping.rs
+++ b/src/dynamic_programming/egg_dropping.rs
@@ -35,7 +35,7 @@ pub fn egg_drop(eggs: u32, floors: u32) -> u32 {
     // Complete solutions vector using optimal substructure property
     for i in 2..=eggs_index {
         for j in 2..=floors_index {
-            egg_drops[i][j] = std::u32::MAX;
+            egg_drops[i][j] = u32::MAX;
 
             for k in 1..=j {
                 let res = 1 + std::cmp::max(egg_drops[i - 1][k - 1], egg_drops[i][j - k]);

--- a/src/general/kmeans.rs
+++ b/src/general/kmeans.rs
@@ -4,7 +4,6 @@ macro_rules! impl_kmeans {
     ($kind: ty, $modname: ident) => {
         // Since we can't overload methods in rust, we have to use namespacing
         pub mod $modname {
-            use std::$modname::INFINITY;
 
             /// computes sum of squared deviation between two identically sized vectors
             /// `x`, and `y`.
@@ -22,7 +21,7 @@ macro_rules! impl_kmeans {
                         // Find the argmin by folding using a tuple containing the argmin
                         // and the minimum distance.
                         let (argmin, _) = centroids.iter().enumerate().fold(
-                            (0_usize, INFINITY),
+                            (0_usize, <$kind>::INFINITY),
                             |(min_ix, min_dist), (ix, ci)| {
                                 let dist = distance(xi, ci);
                                 if dist < min_dist {

--- a/src/graph/bipartite_matching.rs
+++ b/src/graph/bipartite_matching.rs
@@ -74,24 +74,24 @@ impl BipartiteMatching {
                 // else set the vertex distance as infinite because it is matched
                 // this will be considered the next time
 
-                *d_i = i32::max_value();
+                *d_i = i32::MAX;
             }
         }
-        dist[0] = i32::max_value();
+        dist[0] = i32::MAX;
         while !q.is_empty() {
             let u = *q.front().unwrap();
             q.pop_front();
             if dist[u] < dist[0] {
                 for i in 0..self.adj[u].len() {
                     let v = self.adj[u][i];
-                    if dist[self.mt2[v] as usize] == i32::max_value() {
+                    if dist[self.mt2[v] as usize] == i32::MAX {
                         dist[self.mt2[v] as usize] = dist[u] + 1;
                         q.push_back(self.mt2[v] as usize);
                     }
                 }
             }
         }
-        dist[0] != i32::max_value()
+        dist[0] != i32::MAX
     }
     fn dfs(&mut self, u: i32, dist: &mut Vec<i32>) -> bool {
         if u == 0 {
@@ -105,14 +105,14 @@ impl BipartiteMatching {
                 return true;
             }
         }
-        dist[u as usize] = i32::max_value();
+        dist[u as usize] = i32::MAX;
         false
     }
     pub fn hopcroft_karp(&mut self) -> i32 {
         // NOTE: how to use: https://cses.fi/paste/7558dba8d00436a847eab8/
         self.mt2 = vec![0; self.num_vertices_grp2 + 1];
         self.mt1 = vec![0; self.num_vertices_grp1 + 1];
-        let mut dist = vec![i32::max_value(); self.num_vertices_grp1 + 1];
+        let mut dist = vec![i32::MAX; self.num_vertices_grp1 + 1];
         let mut res = 0;
         while self.bfs(&mut dist) {
             for u in 1..self.num_vertices_grp1 + 1 {

--- a/src/graph/disjoint_set_union.rs
+++ b/src/graph/disjoint_set_union.rs
@@ -26,12 +26,12 @@ impl DisjointSetUnion {
         self.nodes[v].parent
     }
     // Returns the new component of the merged sets,
-    // or std::usize::MAX if they were the same.
+    // or usize::MAX if they were the same.
     pub fn merge(&mut self, u: usize, v: usize) -> usize {
         let mut a = self.find_set(u);
         let mut b = self.find_set(v);
         if a == b {
-            return std::usize::MAX;
+            return usize::MAX;
         }
         if self.nodes[a].size < self.nodes[b].size {
             std::mem::swap(&mut a, &mut b);
@@ -79,11 +79,11 @@ mod tests {
         ];
         let mut added_edges: Vec<(usize, usize)> = Vec::new();
         for (u, v) in edges {
-            if dsu.merge(u, v) < std::usize::MAX {
+            if dsu.merge(u, v) < usize::MAX {
                 added_edges.push((u, v));
             }
             // Now they should be the same
-            assert!(dsu.merge(u, v) == std::usize::MAX);
+            assert!(dsu.merge(u, v) == usize::MAX);
         }
         assert_eq!(added_edges, expected_edges);
         let comp_1 = dsu.find_set(1);

--- a/src/graph/minimum_spanning_tree.rs
+++ b/src/graph/minimum_spanning_tree.rs
@@ -41,7 +41,7 @@ pub fn kruskal(mut edges: Vec<Edge>, number_of_vertices: i64) -> (i64, Vec<Edge>
 
         let source: i64 = edge.source;
         let destination: i64 = edge.destination;
-        if dsu.merge(source as usize, destination as usize) < std::usize::MAX {
+        if dsu.merge(source as usize, destination as usize) < usize::MAX {
             merge_count += 1;
             let cost: i64 = edge.cost;
             total_cost += cost;


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`legacy_numeric_constants`](https://rust-lang.github.io/rust-clippy/master/#/legacy_numeric_constants) from the list of suppressed lints. It was added in #754 to fix the failing CI.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
