### PR TITLE
Added graph_coloring algorithm to backtracking

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -3,6 +3,7 @@
 ## Src
   * Backtracking
     * [All Combination Of Size K](https://github.com/TheAlgorithms/Rust/blob/master/src/backtracking/all_combination_of_size_k.rs)
+    * [Graph Coloring](https://github.com/TheAlgorithms/Rust/blob/master/src/backtracking/graph_coloring.rs)
     * [Hamiltonian Cycle](https://github.com/TheAlgorithms/Rust/blob/master/src/backtracking/hamiltonian_cycle.rs)
     * [Knight Tour](https://github.com/TheAlgorithms/Rust/blob/master/src/backtracking/knight_tour.rs)
     * [N Queens](https://github.com/TheAlgorithms/Rust/blob/master/src/backtracking/n_queens.rs)

--- a/src/backtracking/graph_coloring.rs
+++ b/src/backtracking/graph_coloring.rs
@@ -2,7 +2,7 @@
 //it colors the graph in such a way that no two adjacent vertices are of same color
 //if two adjacent vertices are found at same color it aims to solve that using backtracking
 
-
+use std::fmt::Write;
 // Checks whether no two adjacent vertices are of the same color
 fn is_safe(g: &[Vec<i32>], color: &[i32], v: usize, c: i32) -> bool {
     for (i, &val) in g[v].iter().enumerate() {
@@ -15,10 +15,14 @@ fn is_safe(g: &[Vec<i32>], color: &[i32], v: usize, c: i32) -> bool {
 
 // Displays the color assigned to each vertex
 fn display(color: &[i32], solution_number: &mut i32, output: &mut String) {
-    output.push_str(&format!("Solution {}:\n", solution_number));
+    writeln!(output, "Solution {solution_number}:").expect("Failed to write to output");
+
+    println!("{output}");
     *solution_number += 1;
     for (i, &c) in color.iter().enumerate() {
-        output.push_str(&format!("Vertex {} -> Color {}\n", i + 1, c));
+        writeln!(output, "Vertex {} -> Color {}", i + 1, c).expect("Failed to write to output");
+
+        println!("{output}");
     }
     output.push('\n');
 }
@@ -46,9 +50,6 @@ pub fn graph_coloring(
     }
     res
 }
-
-
-
 
 // Test function
 #[cfg(test)]

--- a/src/backtracking/graph_coloring.rs
+++ b/src/backtracking/graph_coloring.rs
@@ -1,0 +1,126 @@
+//graph-colouring uses backtracking algorithm
+//it colors the graph in such a way that no two adjacent vertices are of same color
+//if two adjacent vertices are found at same color it aims to solve that using backtracking
+
+
+// Checks whether no two adjacent vertices are of the same color
+fn is_safe(g: &[Vec<i32>], color: &[i32], v: usize, c: i32) -> bool {
+    for (i, &val) in g[v].iter().enumerate() {
+        if val == 1 && color[i] == c {
+            return false;
+        }
+    }
+    true
+}
+
+// Displays the color assigned to each vertex
+fn display(color: &[i32], solution_number: &mut i32, output: &mut String) {
+    output.push_str(&format!("Solution {}:\n", solution_number));
+    *solution_number += 1;
+    for (i, &c) in color.iter().enumerate() {
+        output.push_str(&format!("Vertex {} -> Color {}\n", i + 1, c));
+    }
+    output.push('\n');
+}
+
+// Solves the graph coloring problem using backtracking
+pub fn graph_coloring(
+    g: &[Vec<i32>],
+    color: &mut [i32],
+    v: usize,
+    m: i32,
+    solution_number: &mut i32,
+    output: &mut String,
+) -> bool {
+    if v == g.len() {
+        display(color, solution_number, output);
+        return true;
+    }
+    let mut res = false;
+    for i in 1..=m {
+        if is_safe(g, color, v, i) {
+            color[v] = i;
+            res = graph_coloring(g, color, v + 1, m, solution_number, output) || res;
+            color[v] = 0;
+        }
+    }
+    res
+}
+
+
+
+
+// Test function
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graph_coloring_check_3() {
+        let g = vec![
+            vec![0, 1, 1, 1],
+            vec![1, 0, 1, 0],
+            vec![1, 1, 0, 1],
+            vec![1, 0, 1, 0],
+        ];
+        let mut color = vec![0; 4];
+        let mut solution_number = 1;
+        let mut output = String::new();
+        let expected_output = "Solution 1:
+Vertex 1 -> Color 1
+Vertex 2 -> Color 2
+Vertex 3 -> Color 3
+Vertex 4 -> Color 2
+
+Solution 2:
+Vertex 1 -> Color 1
+Vertex 2 -> Color 3
+Vertex 3 -> Color 2
+Vertex 4 -> Color 3
+
+Solution 3:
+Vertex 1 -> Color 2
+Vertex 2 -> Color 1
+Vertex 3 -> Color 3
+Vertex 4 -> Color 1
+
+Solution 4:
+Vertex 1 -> Color 2
+Vertex 2 -> Color 3
+Vertex 3 -> Color 1
+Vertex 4 -> Color 3
+
+Solution 5:
+Vertex 1 -> Color 3
+Vertex 2 -> Color 1
+Vertex 3 -> Color 2
+Vertex 4 -> Color 1
+
+Solution 6:
+Vertex 1 -> Color 3
+Vertex 2 -> Color 2
+Vertex 3 -> Color 1
+Vertex 4 -> Color 2
+
+";
+
+        graph_coloring(&g, &mut color, 0, 3, &mut solution_number, &mut output);
+        assert_eq!(expected_output, output);
+    }
+    #[test]
+    fn graph_coloring_check_2() {
+        let g = vec![
+            vec![0, 1, 1, 1],
+            vec![1, 0, 1, 0],
+            vec![1, 1, 0, 1],
+            vec![1, 0, 1, 0],
+        ];
+        let mut color = vec![0; 4];
+        let mut solution_number = 1;
+        let mut output = String::new();
+        let expected_output = "";
+
+        graph_coloring(&g, &mut color, 0, 2, &mut solution_number, &mut output);
+        assert_eq!(expected_output, output);
+    }
+}

--- a/src/backtracking/mod.rs
+++ b/src/backtracking/mod.rs
@@ -1,4 +1,5 @@
 mod all_combination_of_size_k;
+mod graph_coloring;
 mod hamiltonian_cycle;
 mod knight_tour;
 mod n_queens;
@@ -8,6 +9,7 @@ mod rat_in_maze;
 mod sudoku;
 
 pub use all_combination_of_size_k::generate_all_combinations;
+pub use graph_coloring::graph_coloring;
 pub use hamiltonian_cycle::find_hamiltonian_cycle;
 pub use knight_tour::find_knight_tour;
 pub use n_queens::n_queens_solver;


### PR DESCRIPTION
## Description

Graph-coloring algorithm implemented through backtracking .The process colors graph in such a way that no 2 adjacent vertices are of same color.


## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
