### PR TITLE
style: include `inefficient_to_string`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ from_iter_instead_of_collect = { level = "allow", priority = 1 }
 if_not_else = { level = "allow", priority = 1 }
 implicit_clone = { level = "allow", priority = 1 }
 implicit_hasher = { level = "allow", priority = 1 }
-inefficient_to_string = { level = "allow", priority = 1 }
 items_after_statements = { level = "allow", priority = 1 }
 iter_without_into_iter = { level = "allow", priority = 1 }
 linkedlist = { level = "allow", priority = 1 }

--- a/src/ciphers/morse_code.rs
+++ b/src/ciphers/morse_code.rs
@@ -10,7 +10,7 @@ pub fn encode(message: &str) -> String {
         .chars()
         .map(|char| char.to_uppercase().to_string())
         .map(|letter| dictionary.get(letter.as_str()))
-        .map(|option| option.unwrap_or(&UNKNOWN_CHARACTER).to_string())
+        .map(|option| (*option.unwrap_or(&UNKNOWN_CHARACTER)).to_string())
         .collect::<Vec<String>>()
         .join(" ")
 }
@@ -89,10 +89,10 @@ fn _check_all_parts(string: &str) -> bool {
 }
 
 fn _decode_token(string: &str) -> String {
-    _morse_to_alphanumeric_dictionary()
+    (*_morse_to_alphanumeric_dictionary()
         .get(string)
-        .unwrap_or(&_UNKNOWN_MORSE_CHARACTER)
-        .to_string()
+        .unwrap_or(&_UNKNOWN_MORSE_CHARACTER))
+    .to_string()
 }
 
 fn _decode_part(string: &str) -> String {


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`inefficient_to_string`](https://rust-lang.github.io/rust-clippy/master/#/inefficient_to_string) from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
