### PR TITLE
style: include `unnecessary_wraps`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ stable_sort_primitive = { level = "allow", priority = 1 }
 too_many_lines = { level = "allow", priority = 1 }
 trivially_copy_pass_by_ref = { level = "allow", priority = 1 }
 unnecessary_box_returns = { level = "allow", priority = 1 }
-unnecessary_wraps = { level = "allow", priority = 1 }
 unnested_or_patterns = { level = "allow", priority = 1 }
 unreadable_literal = { level = "allow", priority = 1 }
 unused_self = { level = "allow", priority = 1 }

--- a/src/backtracking/graph_coloring.rs
+++ b/src/backtracking/graph_coloring.rs
@@ -26,7 +26,7 @@ pub fn generate_colorings(
     adjacency_matrix: Vec<Vec<bool>>,
     num_colors: usize,
 ) -> Result<Option<Vec<Vec<usize>>>, GraphColoringError> {
-    GraphColoring::new(adjacency_matrix)?.find_solutions(num_colors)
+    Ok(GraphColoring::new(adjacency_matrix)?.find_solutions(num_colors))
 }
 
 /// A struct representing a graph coloring problem.
@@ -126,15 +126,12 @@ impl GraphColoring {
     /// # Returns
     ///
     /// * A `Result` containing an `Option` with a vector of solutions or a `GraphColoringError`.
-    fn find_solutions(
-        &mut self,
-        num_colors: usize,
-    ) -> Result<Option<Vec<Vec<usize>>>, GraphColoringError> {
+    fn find_solutions(&mut self, num_colors: usize) -> Option<Vec<Vec<usize>>> {
         self.find_colorings(0, num_colors);
         if self.solutions.is_empty() {
-            Ok(None)
+            None
         } else {
-            Ok(Some(std::mem::take(&mut self.solutions)))
+            Some(std::mem::take(&mut self.solutions))
         }
     }
 }

--- a/src/sorting/tree_sort.rs
+++ b/src/sorting/tree_sort.rs
@@ -30,19 +30,19 @@ impl<T: Ord + Clone> BinarySearchTree<T> {
     }
 
     fn insert(&mut self, value: T) {
-        self.root = Self::insert_recursive(self.root.take(), value);
+        self.root = Some(Self::insert_recursive(self.root.take(), value));
     }
 
-    fn insert_recursive(root: Option<Box<TreeNode<T>>>, value: T) -> Option<Box<TreeNode<T>>> {
+    fn insert_recursive(root: Option<Box<TreeNode<T>>>, value: T) -> Box<TreeNode<T>> {
         match root {
-            None => Some(Box::new(TreeNode::new(value))),
+            None => Box::new(TreeNode::new(value)),
             Some(mut node) => {
                 if value <= node.value {
-                    node.left = Self::insert_recursive(node.left.take(), value);
+                    node.left = Some(Self::insert_recursive(node.left.take(), value));
                 } else {
-                    node.right = Self::insert_recursive(node.right.take(), value);
+                    node.right = Some(Self::insert_recursive(node.right.take(), value));
                 }
-                Some(node)
+                node
             }
         }
     }


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`unnecessary_wraps`](https://rust-lang.github.io/rust-clippy/master/#/unnecessary_wraps) from the list of suppressed lints. Although it is marked as _MaybeIncorrect_ (buy sill of _pedantic_), I think in these cases it is justified. If we will find some some _false positive_, we can remove this check.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
