### PR TITLE
feat: Implement Circular Deque

### DIFF
--- a/src/data_structures/circular_deque.rs
+++ b/src/data_structures/circular_deque.rs
@@ -1,0 +1,227 @@
+use std::{cell::RefCell, rc::Rc};
+
+#[derive(PartialEq)]
+pub struct Node {
+    val: i32,
+    next: Option<Rc<RefCell<Node>>>,
+}
+
+impl Node {
+    fn new(val: i32) -> Rc<RefCell<Node>> {
+        Rc::new(RefCell::new(Node { val, next: None }))
+    }
+}
+
+pub struct CircularDeque {
+    head: Option<Rc<RefCell<Node>>>,
+    rear: Option<Rc<RefCell<Node>>>,
+    capacity: i32,
+    size: i32,
+}
+
+impl CircularDeque {
+    pub fn new(k: i32) -> Self {
+        CircularDeque {
+            head: None,
+            rear: None,
+            capacity: k,
+            size: 0,
+        }
+    }
+
+    pub fn insert_front(&mut self, value: i32) -> bool {
+        if self.is_full() {
+            return false;
+        }
+
+        let node = Node::new(value);
+
+        if self.is_empty() {
+            self.head = Some(node.clone());
+            self.rear = Some(node);
+        } else {
+            node.borrow_mut().next = self.head.take();
+            self.head = Some(node);
+        }
+
+        self.size += 1;
+        true
+    }
+
+    pub fn insert_last(&mut self, value: i32) -> bool {
+        if self.is_full() {
+            return false;
+        }
+
+        let option_node = Some(Node::new(value));
+
+        if self.is_empty() {
+            self.head.clone_from(&option_node);
+            self.rear = option_node;
+        } else {
+            let rear = self.rear.as_ref().unwrap();
+            rear.borrow_mut().next.clone_from(&option_node);
+
+            self.rear = option_node;
+        }
+
+        self.size += 1;
+        true
+    }
+
+    pub fn delete_front(&mut self) -> bool {
+        if self.is_empty() {
+            return false;
+        } else if self.is_head_rear_equal() {
+            self.rear = None;
+            self.head = None;
+        } else {
+            let head = self.head.take().unwrap();
+            self.head.clone_from(&head.borrow().next);
+        }
+
+        self.size -= 1;
+        true
+    }
+
+    pub fn delete_last(&mut self) -> bool {
+        if self.is_empty() {
+            return false;
+        } else if self.is_head_rear_equal() {
+            self.rear = None;
+            self.head = None;
+        } else {
+            let mut curr = self.head.clone();
+
+            while let Some(node) = curr {
+                let next_node = node.borrow().next.clone();
+                if let Some(next_node) = &next_node {
+                    if Some(next_node) == self.rear.as_ref() {
+                        node.borrow_mut().next = None;
+                        self.rear = Some(node.clone());
+                        break;
+                    }
+                }
+
+                curr = next_node;
+            }
+        }
+
+        self.size -= 1;
+        true
+    }
+
+    pub fn get_front(&self) -> i32 {
+        if let Some(head) = &self.head {
+            head.borrow().val
+        } else {
+            -1
+        }
+    }
+
+    pub fn get_rear(&self) -> i32 {
+        if let Some(rear) = &self.rear {
+            rear.borrow().val
+        } else {
+            -1
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.capacity == self.size
+    }
+
+    pub fn is_head_rear_equal(&self) -> bool {
+        self.head == self.rear
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CircularDeque;
+
+    #[test]
+    fn test_overall() {
+        let mut cq = CircularDeque::new(5);
+
+        cq.insert_front(7);
+        cq.insert_last(0);
+        cq.insert_last(3);
+        assert_eq!(cq.get_front(), 7);
+        cq.insert_front(9);
+        assert_eq!(cq.get_front(), 9);
+        assert_eq!(cq.get_rear(), 3);
+        cq.delete_last();
+        assert_eq!(cq.get_rear(), 0);
+        cq.delete_front();
+        assert_eq!(cq.get_front(), 7);
+        cq.delete_front();
+        assert!(cq.is_head_rear_equal());
+        cq.delete_last();
+        assert!(cq.is_empty())
+    }
+
+    #[test]
+    fn test_empty_and_full() {
+        let mut cq = CircularDeque::new(3);
+
+        assert!(cq.is_empty());
+        assert!(!cq.is_full());
+
+        cq.insert_last(1);
+        cq.insert_last(2);
+        cq.insert_last(3);
+
+        assert!(!cq.is_empty());
+        assert!(cq.is_full());
+    }
+
+    #[test]
+    fn test_insertion_deletion() {
+        let mut cq = CircularDeque::new(3);
+
+        cq.insert_front(1);
+        cq.insert_front(2);
+        cq.insert_last(3);
+
+        assert_eq!(cq.get_front(), 2);
+        assert_eq!(cq.get_rear(), 3);
+
+        cq.delete_front();
+        assert_eq!(cq.get_front(), 1);
+
+        cq.delete_last();
+        assert_eq!(cq.get_rear(), 1);
+
+        cq.insert_last(4);
+        assert_eq!(cq.get_rear(), 4);
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        let mut cq = CircularDeque::new(2);
+
+        assert_eq!(cq.get_front(), -1);
+        assert_eq!(cq.get_rear(), -1);
+
+        cq.insert_last(1);
+        cq.insert_last(2);
+
+        assert_eq!(cq.get_front(), 1);
+        assert_eq!(cq.get_rear(), 2);
+
+        cq.delete_front();
+        assert_eq!(cq.get_front(), 2);
+
+        cq.delete_last();
+        assert!(cq.is_empty());
+
+        cq.insert_front(3);
+        assert_eq!(cq.get_front(), 3);
+        assert_eq!(cq.get_rear(), 3);
+    }
+}

--- a/src/data_structures/mod.rs
+++ b/src/data_structures/mod.rs
@@ -1,6 +1,7 @@
 mod avl_tree;
 mod b_tree;
 mod binary_search_tree;
+mod circular_deque;
 mod fenwick_tree;
 mod floyds_algorithm;
 pub mod graph;
@@ -25,6 +26,7 @@ mod veb_tree;
 pub use self::avl_tree::AVLTree;
 pub use self::b_tree::BTree;
 pub use self::binary_search_tree::BinarySearchTree;
+pub use self::circular_deque::CircularDeque;
 pub use self::fenwick_tree::FenwickTree;
 pub use self::floyds_algorithm::{detect_cycle, has_cycle};
 pub use self::graph::DirectedGraph;


### PR DESCRIPTION
### Changes 

- [x] New feature (non-breaking change which adds circular deque implementation)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
