### PR TITLE
fix: suppress new clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,10 @@ unwrap_used = { level = "allow", priority = 1 }
 use_debug = { level = "allow", priority = 1 }
 wildcard_enum_match_arm = { level = "allow", priority = 1 }
 renamed_function_params = { level = "allow", priority = 1 }
+allow_attributes_without_reason = { level = "allow", priority = 1 }
+allow_attributes = { level = "allow", priority = 1 }
+cfg_not_test = { level = "allow", priority = 1 }
+field_scoped_visibility_modifiers = { level = "allow", priority = 1 }
 # nursery-lints:
 branches_sharing_code = { level = "allow", priority = 1 }
 cognitive_complexity = { level = "allow", priority = 1 }
@@ -163,6 +167,7 @@ suspicious_operation_groupings = { level = "allow", priority = 1 }
 use_self = { level = "allow", priority = 1 }
 while_float = { level = "allow", priority = 1 }
 needless_pass_by_ref_mut = { level = "allow", priority = 1 }
+set_contains_or_insert = { level = "allow", priority = 1 }
 # cargo-lints:
 cargo_common_metadata = { level = "allow", priority = 1 }
 # style-lints:

--- a/src/data_structures/probabilistic/bloom_filter.rs
+++ b/src/data_structures/probabilistic/bloom_filter.rs
@@ -59,6 +59,7 @@ impl<Item: Hash, const CAPACITY: usize> BloomFilter<Item> for BasicBloomFilter<C
 /// We want to store `"Bloom"`. Its hash modulo `CAPACITY` is `5`. Which means we need to set `1` at the last index.
 /// It can be performed by doing `000000 | 000001`
 /// Meaning we can hash the item value, use a modulo to find the index, and do a binary `or` between the current number and the index
+#[allow(dead_code)]
 #[derive(Debug, Default)]
 struct SingleBinaryBloomFilter {
     fingerprint: u128, // let's use 128 bits, the equivalent of using CAPACITY=128 in the previous example


### PR DESCRIPTION
# Pull Request Template

## Description

This PR suppresses the _new_ clippy warnings (cf. https://github.com/TheAlgorithms/Rust/actions/runs/10823322821/job/30028661597).

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
