### PR TITLE
style: include `unneeded_field_pattern`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,6 @@ string_add = { level = "allow", priority = 1 }
 string_slice = { level = "allow", priority = 1 }
 undocumented_unsafe_blocks = { level = "allow", priority = 1 }
 unnecessary_safety_comment = { level = "allow", priority = 1 }
-unneeded_field_pattern = { level = "allow", priority = 1 }
 unreachable = { level = "allow", priority = 1 }
 unseparated_literal_suffix = { level = "allow", priority = 1 }
 unwrap_in_result = { level = "allow", priority = 1 }

--- a/src/graph/astar.rs
+++ b/src/graph/astar.rs
@@ -50,9 +50,9 @@ pub fn astar<V: Ord + Copy, E: Ord + Copy + Add<Output = E> + Zero>(
         state: start,
     });
     while let Some(Candidate {
-        estimated_weight: _,
         real_weight,
         state: current,
+        ..
     }) = queue.pop()
     {
         if current == target {


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`unneeded_field_pattern`](https://rust-lang.github.io/rust-clippy/master/#/unneeded_field_pattern) from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.