### PR TITLE
style: include `set_contains_or_insert`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,6 @@ suspicious_operation_groupings = { level = "allow", priority = 1 }
 use_self = { level = "allow", priority = 1 }
 while_float = { level = "allow", priority = 1 }
 needless_pass_by_ref_mut = { level = "allow", priority = 1 }
-set_contains_or_insert = { level = "allow", priority = 1 }
 # cargo-lints:
 cargo_common_metadata = { level = "allow", priority = 1 }
 # style-lints:

--- a/src/graph/breadth_first_search.rs
+++ b/src/graph/breadth_first_search.rs
@@ -34,8 +34,7 @@ pub fn breadth_first_search(graph: &Graph, root: Node, target: Node) -> Option<V
 
         // Check the neighboring nodes for any that we've not visited yet.
         for neighbor in currentnode.neighbors(graph) {
-            if !visited.contains(&neighbor) {
-                visited.insert(neighbor);
+            if visited.insert(neighbor) {
                 queue.push_back(neighbor);
             }
         }


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`set_contains_or_insert`](https://rust-lang.github.io/rust-clippy/master/#/set_contains_or_insert) from the list of suppressed lints.

Continuation of #743 and #789.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.