### PR TITLE
style: include `iter_on_single_items`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,6 @@ derive_partial_eq_without_eq = { level = "allow", priority = 1 }
 empty_line_after_doc_comments = { level = "allow", priority = 1 }
 fallible_impl_from = { level = "allow", priority = 1 }
 imprecise_flops = { level = "allow", priority = 1 }
-iter_on_single_items = { level = "allow", priority = 1 }
 missing_const_for_fn = { level = "allow", priority = 1 }
 nonstandard_macro_braces = { level = "allow", priority = 1 }
 option_if_let_else = { level = "allow", priority = 1 }

--- a/src/math/field.rs
+++ b/src/math/field.rs
@@ -236,7 +236,7 @@ mod tests {
             for gen in 1..P - 1 {
                 // every field element != 0 generates the whole field additively
                 let gen = PrimeField::from(gen as i64);
-                let mut generated: HashSet<PrimeField<P>> = [gen].into_iter().collect();
+                let mut generated: HashSet<PrimeField<P>> = std::iter::once(gen).collect();
                 let mut x = gen;
                 for _ in 0..P {
                     x = x + gen;


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`iter_on_single_items`](https://rust-lang.github.io/rust-clippy/master/#/iter_on_single_items) from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
