### PR TITLE
chore: suppress new clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ unnested_or_patterns = { level = "allow", priority = 1 }
 unreadable_literal = { level = "allow", priority = 1 }
 unused_self = { level = "allow", priority = 1 }
 used_underscore_binding = { level = "allow", priority = 1 }
+ref_option = { level = "allow", priority = 1 }
 # restriction-lints:
 absolute_paths = { level = "allow", priority = 1 }
 arithmetic_side_effects = { level = "allow", priority = 1 }
@@ -148,6 +149,8 @@ allow_attributes_without_reason = { level = "allow", priority = 1 }
 allow_attributes = { level = "allow", priority = 1 }
 cfg_not_test = { level = "allow", priority = 1 }
 field_scoped_visibility_modifiers = { level = "allow", priority = 1 }
+unused_trait_names = { level = "allow", priority = 1 }
+used_underscore_items = { level = "allow", priority = 1 }
 # nursery-lints:
 branches_sharing_code = { level = "allow", priority = 1 }
 cognitive_complexity = { level = "allow", priority = 1 }
@@ -169,3 +172,6 @@ too_long_first_doc_paragraph = { level = "allow", priority = 1 }
 cargo_common_metadata = { level = "allow", priority = 1 }
 # style-lints:
 doc_lazy_continuation = { level = "allow", priority = 1 }
+needless_return = { level = "allow", priority = 1 }
+# complexity-lints
+needless_lifetimes = { level = "allow", priority = 1 }

--- a/src/data_structures/veb_tree.rs
+++ b/src/data_structures/veb_tree.rs
@@ -215,7 +215,7 @@ pub struct VebTreeIter<'a> {
 }
 
 impl<'a> VebTreeIter<'a> {
-    pub fn new(tree: &'a VebTree) -> VebTreeIter {
+    pub fn new(tree: &'a VebTree) -> VebTreeIter<'a> {
         let curr = if tree.empty() { None } else { Some(tree.min) };
         VebTreeIter { tree, curr }
     }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR suppresses these new clippy warnings, which cause problems. Similar to
- #754
- #789
- #838
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
