### PR TITLE
Added geometric mean to averages.rs

### DIFF
--- a/src/math/average.rs
+++ b/src/math/average.rs
@@ -19,7 +19,6 @@ fn sum<T: Num + Copy>(sequence: Vec<T>) -> T {
     sequence.iter().fold(T::zero(), |acc, x| acc + *x)
 }
 
-#[allow(dead_code)]
 fn product<T: Num + Copy + One + FromPrimitive + ToPrimitive>(sequence: &[T]) -> Option<f64> {
     if sequence.is_empty() {
         None

--- a/src/math/average.rs
+++ b/src/math/average.rs
@@ -6,16 +6,30 @@ The mode is the most frequently occurring value on the list.
 
 Reference: https://www.britannica.com/science/mean-median-and-mode
 
-This program approximates the mean, median and mode of a finite sequence.
+There is also the geometric mean, often used in finance, which is much more suited for rates and other multiplicative
+relationships. The geometric mean is the Nth root of the product of a finite sequence of numbers.
+
+This program approximates the mean, geometric mean, median and mode of a finite sequence.
 Note: Floats sequences are not allowed for `mode` function.
 "]
 use std::collections::HashMap;
 use std::collections::HashSet;
 
-use num_traits::Num;
+use num_traits::{Num, FromPrimitive, ToPrimitive, One};
 
 fn sum<T: Num + Copy>(sequence: Vec<T>) -> T {
     sequence.iter().fold(T::zero(), |acc, x| acc + *x)
+}
+
+fn product<T: Num + Copy + One + FromPrimitive + ToPrimitive>(sequence: &Vec<T>) -> Option<f64> {
+    if sequence.is_empty() {
+        None
+    } else {
+        sequence.iter()
+            .copied()
+            .fold(T::one(), |acc, x| acc * x)
+            .to_f64()
+    }
 }
 
 /// # Argument
@@ -32,6 +46,22 @@ pub fn mean<T: Num + Copy + num_traits::FromPrimitive>(sequence: Vec<T>) -> Opti
 
 fn mean_of_two<T: Num + Copy>(a: T, b: T) -> T {
     (a + b) / (T::one() + T::one())
+}
+
+
+/// # Argument
+///
+/// * `sequence` - A vector of numbers.
+/// Returns geometric mean of `sequence`.
+pub fn geometric_mean<T: Num + Copy + One + FromPrimitive + ToPrimitive>(sequence: &Vec<T>) -> Option<f64> {
+    if sequence.is_empty() {
+        return None;
+    }
+    if sequence.iter().any(|&x| x.to_f64() <= Some(0.0)) {
+        return None;
+    }
+    let product_result = product(sequence)?;
+    Some(product_result.powf(1.0 / sequence.len() as f64))
 }
 
 /// # Argument
@@ -119,4 +149,62 @@ mod test {
         assert!(mean(Vec::<f64>::new()).is_none());
         assert!(mean(Vec::<i32>::new()).is_none());
     }
+
+    // Tests for product function
+    // Empty Product is empty
+    #[test]
+    fn test_product_empty() {
+        let sequence: Vec<i32> = vec![];
+        let result = product(&sequence);
+        assert_eq!(result, None); 
+    }
+
+    // Product of a single value is the value
+    #[test]
+    fn test_product_single_element() {
+        let sequence = vec![10];
+        let result = product(&sequence);
+        assert_eq!(result, Some(10.0));
+    }
+    // Product generic test
+    #[test]
+    fn test_product_floats() {
+        let sequence = vec![1.5, 2.0, 4.0];
+        let result = product(&sequence);
+        assert_eq!(result, Some(12.0));
+    }
+
+    // Tests for geometric mean function
+    // Empty sequence returns nothing
+    #[test]
+    fn test_geometric_mean_empty() {
+        let sequence: Vec<f64> = vec![];
+        let result = geometric_mean(&sequence);
+        assert_eq!(result, None);
+    }
+
+    // Geometric mean of a single value is the value itself.
+    #[test]
+    fn test_geometric_mean_single_element() { 
+        let sequence = vec![5.0];
+        let result = geometric_mean(&sequence);
+        assert_eq!(result, Some(5.0));
+    }
+
+    // Geometric means are not defined for negative values
+    #[test]
+    fn test_geometric_mean_negative() {
+        let sequence = vec![1.0, -3.0, 2.0];
+        let result = geometric_mean(&sequence);
+        assert_eq!(result, None);
+    }
+
+    // Geometric mean generic test
+    #[test]
+    fn test_geometric_mean_floats() {
+        let sequence = vec![0.5, 0.5, 0.3, 0.2];
+        let result = geometric_mean(&sequence);
+        assert_eq!(result, Some(0.34996355115805833));
+    }
+
 }

--- a/src/math/average.rs
+++ b/src/math/average.rs
@@ -6,8 +6,6 @@ The mode is the most frequently occurring value on the list.
 
 Reference: https://www.britannica.com/science/mean-median-and-mode
 
-There is also the geometric mean, often used in finance, which is much more suited for rates and other multiplicative
-relationships. The geometric mean is the Nth root of the product of a finite sequence of numbers.
 
 This program approximates the mean, geometric mean, median and mode of a finite sequence.
 Note: Floats sequences are not allowed for `mode` function.

--- a/src/math/average.rs
+++ b/src/math/average.rs
@@ -174,36 +174,22 @@ mod test {
         assert_eq!(result, Some(12.0));
     }
 
-    // Tests for geometric mean function
-    // Empty sequence returns nothing
-    #[test]
-    fn test_geometric_mean_empty() {
-        let sequence: Vec<f64> = vec![];
-        let result = geometric_mean(&sequence);
-        assert_eq!(result, None);
+    macro_rules! test_geometric_mean {
+        ($($name:ident: $inputs:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let (sequence, expected) = $inputs;
+                assert_eq!(geometric_mean(&sequence), expected);
+            }
+        )*
+        }
     }
 
-    // Geometric mean of a single value is the value itself.
-    #[test]
-    fn test_geometric_mean_single_element() {
-        let sequence = vec![5.0];
-        let result = geometric_mean(&sequence);
-        assert_eq!(result, Some(5.0));
-    }
-
-    // Geometric means are not defined for negative values
-    #[test]
-    fn test_geometric_mean_negative() {
-        let sequence = vec![1.0, -3.0, 2.0];
-        let result = geometric_mean(&sequence);
-        assert_eq!(result, None);
-    }
-
-    // Geometric mean generic test
-    #[test]
-    fn test_geometric_mean_floats() {
-        let sequence = vec![0.5, 0.5, 0.3, 0.2];
-        let result = geometric_mean(&sequence);
-        assert_eq!(result, Some(0.34996355115805833));
+    test_geometric_mean! {
+        empty: (Vec::<f64>::new(), None),
+        single: (vec![5.0], Some(5.0)),
+        negative: (vec![1.0, -3.0, 2.0], None),
+        regular: (vec![0.5, 0.5, 0.3, 0.2], Some(0.34996355115805833)),
     }
 }

--- a/src/math/average.rs
+++ b/src/math/average.rs
@@ -15,17 +15,19 @@ Note: Floats sequences are not allowed for `mode` function.
 use std::collections::HashMap;
 use std::collections::HashSet;
 
-use num_traits::{Num, FromPrimitive, ToPrimitive, One};
+use num_traits::{FromPrimitive, Num, One, ToPrimitive};
 
 fn sum<T: Num + Copy>(sequence: Vec<T>) -> T {
     sequence.iter().fold(T::zero(), |acc, x| acc + *x)
 }
 
-fn product<T: Num + Copy + One + FromPrimitive + ToPrimitive>(sequence: &Vec<T>) -> Option<f64> {
+#[allow(dead_code)]
+fn product<T: Num + Copy + One + FromPrimitive + ToPrimitive>(sequence: &[T]) -> Option<f64> {
     if sequence.is_empty() {
         None
     } else {
-        sequence.iter()
+        sequence
+            .iter()
             .copied()
             .fold(T::one(), |acc, x| acc * x)
             .to_f64()
@@ -48,12 +50,14 @@ fn mean_of_two<T: Num + Copy>(a: T, b: T) -> T {
     (a + b) / (T::one() + T::one())
 }
 
-
 /// # Argument
 ///
 /// * `sequence` - A vector of numbers.
 /// Returns geometric mean of `sequence`.
-pub fn geometric_mean<T: Num + Copy + One + FromPrimitive + ToPrimitive>(sequence: &Vec<T>) -> Option<f64> {
+#[allow(dead_code)]
+pub fn geometric_mean<T: Num + Copy + One + FromPrimitive + ToPrimitive>(
+    sequence: &[T],
+) -> Option<f64> {
     if sequence.is_empty() {
         return None;
     }
@@ -156,7 +160,7 @@ mod test {
     fn test_product_empty() {
         let sequence: Vec<i32> = vec![];
         let result = product(&sequence);
-        assert_eq!(result, None); 
+        assert_eq!(result, None);
     }
 
     // Product of a single value is the value
@@ -185,7 +189,7 @@ mod test {
 
     // Geometric mean of a single value is the value itself.
     #[test]
-    fn test_geometric_mean_single_element() { 
+    fn test_geometric_mean_single_element() {
         let sequence = vec![5.0];
         let result = geometric_mean(&sequence);
         assert_eq!(result, Some(5.0));
@@ -206,5 +210,4 @@ mod test {
         let result = geometric_mean(&sequence);
         assert_eq!(result, Some(0.34996355115805833));
     }
-
 }

--- a/src/math/average.rs
+++ b/src/math/average.rs
@@ -51,7 +51,6 @@ fn mean_of_two<T: Num + Copy>(a: T, b: T) -> T {
 ///
 /// * `sequence` - A vector of numbers.
 /// Returns geometric mean of `sequence`.
-#[allow(dead_code)]
 pub fn geometric_mean<T: Num + Copy + One + FromPrimitive + ToPrimitive>(
     sequence: &[T],
 ) -> Option<f64> {


### PR DESCRIPTION
## Description
Added a geometric mean to the averages.rs file, whilst mean, median and mode are certainly more standard than the geometric mean, it is often used within finance, and a valuable average when confronted with sequences which have a multiplicative nature. I've tried to follow the same style as the previous averages, I'm very new to rust and programming in general so I apologise in advance if I have made some obvious or glaring errors.

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

