### PR TITLE
Added count_vovels in string. (saw it in the python version)

### DIFF
--- a/src/string/count_vovels.rs
+++ b/src/string/count_vovels.rs
@@ -1,0 +1,33 @@
+/// Counts the number of vowels in a given string.
+/// Vowels are defined as 'a', 'e', 'i', 'o', 'u' (both uppercase and lowercase).
+pub fn count_vowels(input: &str) -> usize {
+    input.chars().filter(|c| "aeiouAEIOU".contains(*c)).count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_count_vowels {
+    ($($name:ident: $tc:expr,)*) => {
+      $(
+        #[test]
+        fn $name() {
+          let (input, expected) = $tc;
+          assert_eq!(count_vowels(input), expected);
+        }
+      )*
+    }
+  }
+
+    test_count_vowels! {
+      empty_string: ("", 0),
+      no_vowels: ("ghfdryfs", 0),
+      all_vowels_lowercase: ("aeiou", 5),
+      all_vowels_uppercase: ("AEIOU", 5),
+      mixed_vowels: ("aEIoU", 5),
+      hello_world: ("Hello, World!", 3),
+      long_string: (&"a".repeat(1000), 1000),
+      string_with_special_chars: ("!@%^&+aei*()_o#$u", 5),
+    }
+}

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -3,6 +3,7 @@ mod anagram;
 mod autocomplete_using_trie;
 mod boyer_moore_search;
 mod burrows_wheeler_transform;
+mod count_vowels;
 mod duval_algorithm;
 mod hamming_distance;
 mod isogram;
@@ -30,6 +31,7 @@ pub use self::boyer_moore_search::boyer_moore_search;
 pub use self::burrows_wheeler_transform::{
     burrows_wheeler_transform, inv_burrows_wheeler_transform,
 };
+pub use self::count_vowels::count_vowels;
 pub use self::duval_algorithm::duval_algorithm;
 pub use self::hamming_distance::hamming_distance;
 pub use self::isogram::is_isogram;


### PR DESCRIPTION
## Description

Added a `count_vovels` algorithm to the string category. Uses a basic O(n) algorithms, (where n = number of characters in the string). Checks whether any of the characters in the string is 'a','e','i','o','u','A','E','I','O', or 'U'. It uses the filter() method to quickly check for it. 

`input.chars().filter(|c| "aeiouAEIOU".contains(*c)).count()`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

(However there seems to be a function in the cypher category that might be causing an error)
