### PR TITLE
style: include `redundant_clone`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,6 @@ imprecise_flops = { level = "allow", priority = 1 }
 missing_const_for_fn = { level = "allow", priority = 1 }
 nonstandard_macro_braces = { level = "allow", priority = 1 }
 option_if_let_else = { level = "allow", priority = 1 }
-redundant_clone = { level = "allow", priority = 1 }
 suboptimal_flops = { level = "allow", priority = 1 }
 suspicious_operation_groupings = { level = "allow", priority = 1 }
 use_self = { level = "allow", priority = 1 }

--- a/src/graph/decremental_connectivity.rs
+++ b/src/graph/decremental_connectivity.rs
@@ -224,7 +224,7 @@ mod tests {
             HashSet::from([7, 8]),
             HashSet::from([7]),
         ];
-        let mut dec_con = super::DecrementalConnectivity::new(adjacent.clone()).unwrap();
+        let mut dec_con = super::DecrementalConnectivity::new(adjacent).unwrap();
         dec_con.delete(2, 4);
     }
 
@@ -260,7 +260,7 @@ mod tests {
         dec_con2.delete(4, 1);
         assert!(!dec_con2.connected(1, 4).unwrap());
 
-        let mut dec_con3 = super::DecrementalConnectivity::new(adjacent.clone()).unwrap();
+        let mut dec_con3 = super::DecrementalConnectivity::new(adjacent).unwrap();
         dec_con3.delete(1, 4);
         assert!(!dec_con3.connected(4, 1).unwrap());
     }

--- a/src/machine_learning/cholesky.rs
+++ b/src/machine_learning/cholesky.rs
@@ -38,7 +38,7 @@ mod tests {
     fn test_cholesky() {
         // Test case 1
         let mat1 = vec![25.0, 15.0, -5.0, 15.0, 18.0, 0.0, -5.0, 0.0, 11.0];
-        let res1 = cholesky(mat1.clone(), 3);
+        let res1 = cholesky(mat1, 3);
 
         // The expected Cholesky decomposition values
         #[allow(clippy::useless_vec)]
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     fn matrix_with_all_zeros() {
         let mat3 = vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
-        let res3 = cholesky(mat3.clone(), 3);
+        let res3 = cholesky(mat3, 3);
         let expected3 = vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         assert_eq!(res3, expected3);
     }

--- a/src/math/softmax.rs
+++ b/src/math/softmax.rs
@@ -20,7 +20,7 @@
 use std::f32::consts::E;
 
 pub fn softmax(array: Vec<f32>) -> Vec<f32> {
-    let mut softmax_array = array.clone();
+    let mut softmax_array = array;
 
     for value in &mut softmax_array {
         *value = E.powf(*value);


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`redundant_clone`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone) from the list of from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
