### PR TITLE
style: include `needless_pass_by_ref_mut`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,6 @@ suboptimal_flops = { level = "allow", priority = 1 }
 suspicious_operation_groupings = { level = "allow", priority = 1 }
 use_self = { level = "allow", priority = 1 }
 while_float = { level = "allow", priority = 1 }
-needless_pass_by_ref_mut = { level = "allow", priority = 1 }
 too_long_first_doc_paragraph = { level = "allow", priority = 1 }
 # cargo-lints:
 cargo_common_metadata = { level = "allow", priority = 1 }

--- a/src/backtracking/rat_in_maze.rs
+++ b/src/backtracking/rat_in_maze.rs
@@ -60,7 +60,7 @@ pub fn find_path_in_maze(
     }
 
     // If validations pass, proceed with finding the path
-    let mut maze_instance = Maze::new(maze.to_owned());
+    let maze_instance = Maze::new(maze.to_owned());
     Ok(maze_instance.find_path(start_x, start_y))
 }
 
@@ -114,7 +114,7 @@ impl Maze {
     /// # Returns
     ///
     /// A solution matrix if a path is found or None if not found.
-    fn find_path(&mut self, start_x: usize, start_y: usize) -> Option<Vec<Vec<bool>>> {
+    fn find_path(&self, start_x: usize, start_y: usize) -> Option<Vec<Vec<bool>>> {
         let mut solution = vec![vec![false; self.width()]; self.height()];
         if self.solve(start_x as isize, start_y as isize, &mut solution) {
             Some(solution)

--- a/src/string/z_algorithm.rs
+++ b/src/string/z_algorithm.rs
@@ -42,7 +42,7 @@ fn calculate_z_value<T: Eq>(
 /// # Returns
 /// The initialized Z-array value for the current index.
 fn initialize_z_array_from_previous_match(
-    z_array: &mut [usize],
+    z_array: &[usize],
     i: usize,
     match_end: usize,
     last_match: usize,
@@ -92,8 +92,7 @@ fn match_with_z_array<T: Eq>(
 
     for i in start_index..size {
         if i <= match_end {
-            z_array[i] =
-                initialize_z_array_from_previous_match(&mut z_array, i, match_end, last_match);
+            z_array[i] = initialize_z_array_from_previous_match(&z_array, i, match_end, last_match);
         }
 
         z_array[i] = calculate_z_value(input_string, pattern, i, z_array[i]);


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`needless_pass_by_ref_mut`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut) from the list of from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
