### PR TITLE
style: include `get_unwrap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,6 @@ exhaustive_structs = { level = "allow", priority = 1 }
 expect_used = { level = "allow", priority = 1 }
 float_arithmetic = { level = "allow", priority = 1 }
 float_cmp_const = { level = "allow", priority = 1 }
-get_unwrap = { level = "allow", priority = 1 }
 if_then_some_else_none = { level = "allow", priority = 1 }
 impl_trait_in_params = { level = "allow", priority = 1 }
 implicit_return = { level = "allow", priority = 1 }

--- a/src/big_integer/fast_factorial.rs
+++ b/src/big_integer/fast_factorial.rs
@@ -36,7 +36,7 @@ pub fn fast_factorial(n: usize) -> BigUint {
         .map(|p| (p, index(p, n)))
         .collect::<BTreeMap<_, _>>();
 
-    let max_bits = p_indices.get(&2).unwrap().next_power_of_two().ilog2() + 1;
+    let max_bits = p_indices[&2].next_power_of_two().ilog2() + 1;
 
     // Create a Vec of 1's
     let mut a = vec![BigUint::one(); max_bits as usize];

--- a/src/dynamic_programming/fibonacci.rs
+++ b/src/dynamic_programming/fibonacci.rs
@@ -213,7 +213,7 @@ pub fn nth_fibonacci_number_modulo_m(n: i64, m: i64) -> i128 {
     let (length, pisano_sequence) = get_pisano_sequence_and_period(m);
 
     let remainder = n % length as i64;
-    pisano_sequence.get(remainder as usize).unwrap().to_owned()
+    pisano_sequence[remainder as usize].to_owned()
 }
 
 /// get_pisano_sequence_and_period(m) returns the Pisano Sequence and period for the specified integer m.

--- a/src/general/huffman_encoding.rs
+++ b/src/general/huffman_encoding.rs
@@ -111,7 +111,7 @@ impl<T: Clone + Copy + Ord> HuffmanDictionary<T> {
     pub fn encode(&self, data: &[T]) -> HuffmanEncoding {
         let mut result = HuffmanEncoding::new();
         data.iter()
-            .for_each(|value| result.add_data(*self.alphabet.get(value).unwrap()));
+            .for_each(|value| result.add_data(self.alphabet[value]));
         result
     }
 }

--- a/src/math/nthprime.rs
+++ b/src/math/nthprime.rs
@@ -39,8 +39,8 @@ fn get_primes(s: u64) -> Vec<u64> {
 
 fn count_prime(primes: Vec<u64>, n: u64) -> Option<u64> {
     let mut counter: u64 = 0;
-    for i in 2..primes.len() {
-        counter += primes.get(i).unwrap();
+    for (i, prime) in primes.iter().enumerate().skip(2) {
+        counter += prime;
         if counter == n {
             return Some(i as u64);
         }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`get_unwrap`](https://rust-lang.github.io/rust-clippy/master/index.html#get_unwrap) from the list of from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
