### PR TITLE
style: include `needless_for_each`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ missing_fields_in_debug = { level = "allow", priority = 1 }
 missing_panics_doc = { level = "allow", priority = 1 }
 module_name_repetitions = { level = "allow", priority = 1 }
 must_use_candidate = { level = "allow", priority = 1 }
-needless_for_each = { level = "allow", priority = 1 }
 needless_pass_by_value = { level = "allow", priority = 1 }
 range_plus_one = { level = "allow", priority = 1 }
 redundant_closure_for_method_calls = { level = "allow", priority = 1 }

--- a/src/ciphers/transposition.rs
+++ b/src/ciphers/transposition.rs
@@ -20,7 +20,6 @@ pub fn transposition(decrypt_mode: bool, msg: &str, key: &str) -> String {
 
     for cipher_key in keys.iter() {
         let mut key_order: Vec<usize> = Vec::new();
-        let mut counter: u8 = 0;
 
         // Removes any non-alphabet characters from 'msg'
         cipher_msg = cipher_msg
@@ -36,10 +35,9 @@ pub fn transposition(decrypt_mode: bool, msg: &str, key: &str) -> String {
 
         key_ascii.sort_by_key(|&(_, key)| key);
 
-        key_ascii.iter_mut().for_each(|(_, key)| {
-            *key = counter;
-            counter += 1;
-        });
+        for (counter, (_, key)) in key_ascii.iter_mut().enumerate() {
+            *key = counter as u8;
+        }
 
         key_ascii.sort_by_key(|&(index, _)| index);
 
@@ -91,18 +89,16 @@ fn encrypt(mut msg: String, key_order: Vec<usize>) -> String {
     // alphabetical order of the keyword's characters
     let mut indexed_vec: Vec<(usize, &String)> = Vec::new();
     let mut indexed_msg: String = String::from("");
-    let mut counter: usize = 0;
 
-    key_order.into_iter().for_each(|key_index| {
+    for (counter, key_index) in key_order.into_iter().enumerate() {
         indexed_vec.push((key_index, &encrypted_vec[counter]));
-        counter += 1;
-    });
+    }
 
     indexed_vec.sort();
 
-    indexed_vec.into_iter().for_each(|(_, column)| {
+    for (_, column) in indexed_vec {
         indexed_msg.push_str(column);
-    });
+    }
 
     // Split the message by a space every nth character, determined by
     // 'message length divided by keyword length' to the next highest integer.
@@ -153,19 +149,19 @@ fn decrypt(mut msg: String, key_order: Vec<usize>) -> String {
         msg.replace_range(range, "");
     });
 
-    split_small.iter_mut().for_each(|key_index| {
+    for key_index in split_small.iter_mut() {
         let (slice, rest_of_msg) = msg.split_at(split_size);
         indexed_vec.push((*key_index, (slice.to_string())));
         msg = rest_of_msg.to_string();
-    });
+    }
 
     indexed_vec.sort();
 
-    key_order.into_iter().for_each(|key| {
+    for key in key_order {
         if let Some((_, column)) = indexed_vec.iter().find(|(key_index, _)| key_index == &key) {
             decrypted_vec.push(column.to_string());
         }
-    });
+    }
 
     // Concatenate the columns into a string, determined by the
     // alphabetical order of the keyword's characters

--- a/src/graph/two_satisfiability.rs
+++ b/src/graph/two_satisfiability.rs
@@ -24,12 +24,12 @@ pub fn solve_two_satisfiability(
     let mut sccs = SCCs::new(num_verts);
     let mut adj = Graph::new();
     adj.resize(num_verts, vec![]);
-    expression.iter().for_each(|cond| {
+    for cond in expression.iter() {
         let v1 = variable(cond.0);
         let v2 = variable(cond.1);
         adj[v1 ^ 1].push(v2);
         adj[v2 ^ 1].push(v1);
-    });
+    }
     sccs.find_components(&adj);
     result.resize(num_variables + 1, false);
     for var in (2..num_verts).step_by(2) {

--- a/src/searching/moore_voting.rs
+++ b/src/searching/moore_voting.rs
@@ -46,7 +46,7 @@ pub fn moore_voting(arr: &[i32]) -> i32 {
     let mut cnt = 0; // initializing cnt
     let mut ele = 0; // initializing ele
 
-    arr.iter().for_each(|&item| {
+    for &item in arr.iter() {
         if cnt == 0 {
             cnt = 1;
             ele = item;
@@ -55,7 +55,7 @@ pub fn moore_voting(arr: &[i32]) -> i32 {
         } else {
             cnt -= 1;
         }
-    });
+    }
 
     let cnt_check = arr.iter().filter(|&&x| x == ele).count();
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`needless_for_each`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_for_each) from the list of from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
