### PR TITLE
style: include `match_bool`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ manual_assert = { level = "allow", priority = 1 }
 manual_let_else = { level = "allow", priority = 1 }
 manual_string_new = { level = "allow", priority = 1 }
 many_single_char_names = { level = "allow", priority = 1 }
-match_bool = { level = "allow", priority = 1 }
 match_on_vec_items = { level = "allow", priority = 1 }
 match_same_arms = { level = "allow", priority = 1 }
 match_wildcard_for_single_variants = { level = "allow", priority = 1 }

--- a/src/ciphers/transposition.rs
+++ b/src/ciphers/transposition.rs
@@ -13,9 +13,10 @@ pub fn transposition(decrypt_mode: bool, msg: &str, key: &str) -> String {
     let key_uppercase: String = key.to_uppercase();
     let mut cipher_msg: String = msg.to_string();
 
-    let keys: Vec<&str> = match decrypt_mode {
-        false => key_uppercase.split_whitespace().collect(),
-        true => key_uppercase.split_whitespace().rev().collect(),
+    let keys: Vec<&str> = if decrypt_mode {
+        key_uppercase.split_whitespace().rev().collect()
+    } else {
+        key_uppercase.split_whitespace().collect()
     };
 
     for cipher_key in keys.iter() {
@@ -47,9 +48,10 @@ pub fn transposition(decrypt_mode: bool, msg: &str, key: &str) -> String {
 
         // Determines whether to encrypt or decrypt the message,
         // and returns the result
-        cipher_msg = match decrypt_mode {
-            false => encrypt(cipher_msg, key_order),
-            true => decrypt(cipher_msg, key_order),
+        cipher_msg = if decrypt_mode {
+            decrypt(cipher_msg, key_order)
+        } else {
+            encrypt(cipher_msg, key_order)
         };
     }
 

--- a/src/general/huffman_encoding.rs
+++ b/src/general/huffman_encoding.rs
@@ -155,9 +155,10 @@ impl HuffmanEncoding {
                 result.push(state.symbol.unwrap());
                 state = &dict.root;
             }
-            match self.get_bit(i) {
-                false => state = state.left.as_ref().unwrap(),
-                true => state = state.right.as_ref().unwrap(),
+            state = if self.get_bit(i) {
+                state.right.as_ref().unwrap()
+            } else {
+                state.left.as_ref().unwrap()
             }
         }
         if self.num_bits > 0 {

--- a/src/sorting/mod.rs
+++ b/src/sorting/mod.rs
@@ -82,17 +82,16 @@ where
 {
     use std::collections::HashSet;
 
-    match a.len() == b.len() {
-        true => {
-            // This is O(n^2) but performs better on smaller data sizes
-            //b.iter().all(|item| a.contains(item))
+    if a.len() == b.len() {
+        // This is O(n^2) but performs better on smaller data sizes
+        //b.iter().all(|item| a.contains(item))
 
-            // This is O(n), performs well on larger data sizes
-            let set_a: HashSet<&T> = a.iter().collect();
-            let set_b: HashSet<&T> = b.iter().collect();
-            set_a == set_b
-        }
-        false => false,
+        // This is O(n), performs well on larger data sizes
+        let set_a: HashSet<&T> = a.iter().collect();
+        let set_b: HashSet<&T> = b.iter().collect();
+        set_a == set_b
+    } else {
+        false
     }
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`match_bool`](https://rust-lang.github.io/rust-clippy/master/index.html#match_bool) from the list of from the list of suppressed lints.

Continuation of #743.

This PR was created at 241 km/h.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
