### PR TITLE
style: include `redundant_type_annotations`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,6 @@ print_stdout = { level = "allow", priority = 1 }
 pub_use = { level = "allow", priority = 1 }
 pub_with_shorthand = { level = "allow", priority = 1 }
 question_mark_used = { level = "allow", priority = 1 }
-redundant_type_annotations = { level = "allow", priority = 1 }
 same_name_method = { level = "allow", priority = 1 }
 semicolon_outside_block = { level = "allow", priority = 1 }
 separated_literal_suffix = { level = "allow", priority = 1 }

--- a/src/ciphers/transposition.rs
+++ b/src/ciphers/transposition.rs
@@ -10,7 +10,7 @@ use std::ops::Range;
 /// Encrypts or decrypts a message, using multiple keys. The
 /// encryption is based on the columnar transposition method.
 pub fn transposition(decrypt_mode: bool, msg: &str, key: &str) -> String {
-    let key_uppercase: String = key.to_uppercase();
+    let key_uppercase = key.to_uppercase();
     let mut cipher_msg: String = msg.to_string();
 
     let keys: Vec<&str> = match decrypt_mode {
@@ -61,7 +61,7 @@ fn encrypt(mut msg: String, key_order: Vec<usize>) -> String {
     let mut encrypted_msg: String = String::from("");
     let mut encrypted_vec: Vec<String> = Vec::new();
 
-    let msg_len: usize = msg.len();
+    let msg_len = msg.len();
     let key_len: usize = key_order.len();
 
     let mut msg_index: usize = msg_len;
@@ -75,7 +75,7 @@ fn encrypt(mut msg: String, key_order: Vec<usize>) -> String {
 
         // Loop every nth character, determined by key length, to create a column
         while index < msg_index {
-            let ch: char = msg.remove(index);
+            let ch = msg.remove(index);
             chars.push(ch);
 
             index += key_index;
@@ -123,7 +123,7 @@ fn decrypt(mut msg: String, key_order: Vec<usize>) -> String {
     let mut decrypted_vec: Vec<String> = Vec::new();
     let mut indexed_vec: Vec<(usize, String)> = Vec::new();
 
-    let msg_len: usize = msg.len();
+    let msg_len = msg.len();
     let key_len: usize = key_order.len();
 
     // Split the message into columns, determined by 'message length divided by keyword length'.

--- a/src/machine_learning/k_means.rs
+++ b/src/machine_learning/k_means.rs
@@ -11,8 +11,8 @@ fn find_nearest(data_point: &(f64, f64), centroids: &[(f64, f64)]) -> u32 {
     let mut cluster: u32 = 0;
 
     for (i, c) in centroids.iter().enumerate() {
-        let d1: f64 = get_distance(data_point, c);
-        let d2: f64 = get_distance(data_point, &centroids[cluster as usize]);
+        let d1 = get_distance(data_point, c);
+        let d2 = get_distance(data_point, &centroids[cluster as usize]);
 
         if d1 < d2 {
             cluster = i as u32;
@@ -44,7 +44,7 @@ pub fn k_means(data_points: Vec<(f64, f64)>, n_clusters: usize, max_iter: i32) -
         let mut new_centroids_num: Vec<u32> = vec![0; n_clusters];
 
         for (i, d) in data_points.iter().enumerate() {
-            let nearest_cluster: u32 = find_nearest(d, &centroids);
+            let nearest_cluster = find_nearest(d, &centroids);
             labels[i] = nearest_cluster;
 
             new_centroids_position[nearest_cluster as usize].0 += d.0;

--- a/src/machine_learning/loss_function/hinge_loss.rs
+++ b/src/machine_learning/loss_function/hinge_loss.rs
@@ -16,7 +16,7 @@
 pub fn hng_loss(y_true: &[f64], y_pred: &[f64]) -> f64 {
     let mut total_loss: f64 = 0.0;
     for (p, a) in y_pred.iter().zip(y_true.iter()) {
-        let loss: f64 = (1.0 - a * p).max(0.0);
+        let loss = (1.0 - a * p).max(0.0);
         total_loss += loss;
     }
     total_loss / (y_pred.len() as f64)

--- a/src/machine_learning/loss_function/mean_absolute_error_loss.rs
+++ b/src/machine_learning/loss_function/mean_absolute_error_loss.rs
@@ -17,7 +17,7 @@ pub fn mae_loss(predicted: &[f64], actual: &[f64]) -> f64 {
     let mut total_loss: f64 = 0.0;
     for (p, a) in predicted.iter().zip(actual.iter()) {
         let diff: f64 = p - a;
-        let absolute_diff: f64 = diff.abs();
+        let absolute_diff = diff.abs();
         total_loss += absolute_diff;
     }
     total_loss / (predicted.len() as f64)

--- a/src/math/area_under_curve.rs
+++ b/src/math/area_under_curve.rs
@@ -8,7 +8,7 @@ pub fn area_under_curve(start: f64, end: f64, func: fn(f64) -> f64, step_count: 
     }; //swap if bounds reversed
 
     let step_length: f64 = (end - start) / step_count as f64;
-    let mut area: f64 = 0f64;
+    let mut area = 0f64;
     let mut fx1 = func(start);
     let mut fx2: f64;
 

--- a/src/math/logarithm.rs
+++ b/src/math/logarithm.rs
@@ -9,7 +9,7 @@ use std::f64::consts::E;
 ///
 /// Advisable to use **std::f64::consts::*** for specific bases (like 'e')
 pub fn log<T: Into<f64>, U: Into<f64>>(base: U, x: T, tol: f64) -> f64 {
-    let mut rez: f64 = 0f64;
+    let mut rez = 0f64;
     let mut argument: f64 = x.into();
     let usable_base: f64 = base.into();
 

--- a/src/math/prime_numbers.rs
+++ b/src/math/prime_numbers.rs
@@ -6,7 +6,7 @@ pub fn prime_numbers(max: usize) -> Vec<usize> {
     }
     for i in (3..max + 1).step_by(2) {
         let stop: usize = (i as f64).sqrt() as usize + 1;
-        let mut status: bool = true;
+        let mut status = true;
 
         for j in (3..stop).step_by(2) {
             if i % j == 0 {

--- a/src/math/sum_of_digits.rs
+++ b/src/math/sum_of_digits.rs
@@ -14,7 +14,7 @@
 /// ```
 pub fn sum_digits_iterative(num: i32) -> u32 {
     // convert to unsigned integer
-    let mut num: u32 = num.unsigned_abs();
+    let mut num = num.unsigned_abs();
     // initialize sum
     let mut result: u32 = 0;
 
@@ -43,7 +43,7 @@ pub fn sum_digits_iterative(num: i32) -> u32 {
 /// ```
 pub fn sum_digits_recursive(num: i32) -> u32 {
     // convert to unsigned integer
-    let num: u32 = num.unsigned_abs();
+    let num = num.unsigned_abs();
     // base case
     if num < 10 {
         return num;

--- a/src/string/run_length_encoding.rs
+++ b/src/string/run_length_encoding.rs
@@ -29,7 +29,7 @@ pub fn run_length_decoding(target: &str) -> String {
     if target.trim().is_empty() {
         return "".to_string();
     }
-    let mut character_count: String = String::new();
+    let mut character_count = String::new();
     let mut decoded_target = String::new();
 
     for c in target.chars() {


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`redundant_type_annotations`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_type_annotations) from the list of from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
