### PR TITLE
style: include `redundant_else`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ must_use_candidate = { level = "allow", priority = 1 }
 needless_pass_by_value = { level = "allow", priority = 1 }
 range_plus_one = { level = "allow", priority = 1 }
 redundant_closure_for_method_calls = { level = "allow", priority = 1 }
-redundant_else = { level = "allow", priority = 1 }
 return_self_not_must_use = { level = "allow", priority = 1 }
 semicolon_if_nothing_returned = { level = "allow", priority = 1 }
 should_panic_without_expect = { level = "allow", priority = 1 }

--- a/src/data_structures/b_tree.rs
+++ b/src/data_structures/b_tree.rs
@@ -152,9 +152,8 @@ where
                 Err(index) => {
                     if current_node.is_leaf() {
                         return false;
-                    } else {
-                        current_node = &current_node.children[index];
                     }
+                    current_node = &current_node.children[index];
                 }
             }
         }

--- a/src/general/kmeans.rs
+++ b/src/general/kmeans.rs
@@ -88,9 +88,8 @@ macro_rules! impl_kmeans {
                     {
                         // We need to use `return` to break out of the `loop`
                         return clustering;
-                    } else {
-                        clustering = new_clustering;
                     }
+                    clustering = new_clustering;
                 }
             }
         }

--- a/src/graph/depth_first_search_tic_tac_toe.rs
+++ b/src/graph/depth_first_search_tic_tac_toe.rs
@@ -95,14 +95,13 @@ fn main() {
             if result.is_none() {
                 println!("Not a valid empty coordinate.");
                 continue;
-            } else {
-                board[move_pos.y as usize][move_pos.x as usize] = Players::PlayerX;
+            }
+            board[move_pos.y as usize][move_pos.x as usize] = Players::PlayerX;
 
-                if win_check(Players::PlayerX, &board) {
-                    display_board(&board);
-                    println!("Player X Wins!");
-                    return;
-                }
+            if win_check(Players::PlayerX, &board) {
+                display_board(&board);
+                println!("Player X Wins!");
+                return;
             }
 
             //Find the best game plays from the current board state

--- a/src/searching/saddleback_search.rs
+++ b/src/searching/saddleback_search.rs
@@ -22,9 +22,8 @@ pub fn saddleback_search(matrix: &[Vec<i32>], element: i32) -> (usize, usize) {
                 // If the target element is smaller, move to the previous column (leftwards)
                 if right_index == 0 {
                     break; // If we reach the left-most column, exit the loop
-                } else {
-                    right_index -= 1;
                 }
+                right_index -= 1;
             }
         }
     }

--- a/src/searching/ternary_search_min_max_recursive.rs
+++ b/src/searching/ternary_search_min_max_recursive.rs
@@ -16,9 +16,8 @@ pub fn ternary_search_max_rec(
             return ternary_search_max_rec(f, mid1, end, absolute_precision);
         } else if r1 > r2 {
             return ternary_search_max_rec(f, start, mid2, absolute_precision);
-        } else {
-            return ternary_search_max_rec(f, mid1, mid2, absolute_precision);
         }
+        return ternary_search_max_rec(f, mid1, mid2, absolute_precision);
     }
     f(start)
 }
@@ -41,9 +40,8 @@ pub fn ternary_search_min_rec(
             return ternary_search_min_rec(f, start, mid2, absolute_precision);
         } else if r1 > r2 {
             return ternary_search_min_rec(f, mid1, end, absolute_precision);
-        } else {
-            return ternary_search_min_rec(f, mid1, mid2, absolute_precision);
         }
+        return ternary_search_min_rec(f, mid1, mid2, absolute_precision);
     }
     f(start)
 }

--- a/src/string/aho_corasick.rs
+++ b/src/string/aho_corasick.rs
@@ -51,9 +51,8 @@ impl AhoCorasick {
                                 child.lengths.extend(node.borrow().lengths.clone());
                                 child.suffix = Rc::downgrade(node);
                                 break;
-                            } else {
-                                suffix = suffix.unwrap().borrow().suffix.upgrade();
                             }
+                            suffix = suffix.unwrap().borrow().suffix.upgrade();
                         }
                     }
                 }

--- a/src/string/jaro_winkler_distance.rs
+++ b/src/string/jaro_winkler_distance.rs
@@ -43,12 +43,11 @@ pub fn jaro_winkler_distance(str1: &str, str2: &str) -> f64 {
     let jaro: f64 = {
         if match_count == 0 {
             return 0.0;
-        } else {
-            (1_f64 / 3_f64)
-                * (match_count as f64 / str1.len() as f64
-                    + match_count as f64 / str2.len() as f64
-                    + (match_count - transpositions) as f64 / match_count as f64)
         }
+        (1_f64 / 3_f64)
+            * (match_count as f64 / str1.len() as f64
+                + match_count as f64 / str2.len() as f64
+                + (match_count - transpositions) as f64 / match_count as f64)
     };
 
     let mut prefix_len = 0.0;


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`redundant_else`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_else) from the list of from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
