### PR TITLE
style: include `default_trait_access`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ cast_possible_wrap = { level = "allow", priority = 1 }
 cast_precision_loss = { level = "allow", priority = 1 }
 cast_sign_loss = { level = "allow", priority = 1 }
 cloned_instead_of_copied = { level = "allow", priority = 1 }
-default_trait_access = { level = "allow", priority = 1 }
 doc_markdown = { level = "allow", priority = 1 }
 enum_glob_use = { level = "allow", priority = 1 }
 explicit_deref_methods = { level = "allow", priority = 1 }

--- a/src/data_structures/probabilistic/count_min_sketch.rs
+++ b/src/data_structures/probabilistic/count_min_sketch.rs
@@ -109,7 +109,7 @@ impl<T: Hash, const WIDTH: usize, const DEPTH: usize> Default
         let hashers = std::array::from_fn(|_| RandomState::new());
 
         Self {
-            phantom: Default::default(),
+            phantom: std::marker::PhantomData,
             counts: [[0; WIDTH]; DEPTH],
             hashers,
         }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`default_trait_access`](https://rust-lang.github.io/rust-clippy/master/index.html#default_trait_access) from the list of from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
