### PR TITLE
style: include `bool_to_int_with_if`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ restriction = "warn"
 nursery = "warn"
 cargo = "warn"
 # pedantic-lints:
-bool_to_int_with_if = { level = "allow", priority = 1 }
 cast_lossless = { level = "allow", priority = 1 }
 cast_possible_truncation = { level = "allow", priority = 1 }
 cast_possible_wrap = { level = "allow", priority = 1 }

--- a/src/data_structures/probabilistic/bloom_filter.rs
+++ b/src/data_structures/probabilistic/bloom_filter.rs
@@ -108,7 +108,7 @@ pub struct MultiBinaryBloomFilter {
 
 impl MultiBinaryBloomFilter {
     pub fn with_dimensions(filter_size: usize, hash_count: usize) -> Self {
-        let bytes_count = filter_size / 8 + if filter_size % 8 > 0 { 1 } else { 0 }; // we need 8 times less entries in the array, since we are using bytes. Careful that we have at least one element though
+        let bytes_count = filter_size / 8 + usize::from(filter_size % 8 > 0); // we need 8 times less entries in the array, since we are using bytes. Careful that we have at least one element though
         Self {
             filter_size,
             bytes: vec![0; bytes_count],

--- a/src/string/levenshtein_distance.rs
+++ b/src/string/levenshtein_distance.rs
@@ -50,11 +50,7 @@ pub fn naive_levenshtein_distance(string1: &str, string2: &str) -> usize {
 
     let updated_matrix = (1..=string1.len()).fold(distance_matrix, |matrix, i| {
         (1..=string2.len()).fold(matrix, |mut inner_matrix, j| {
-            let cost = if string1.as_bytes()[i - 1] == string2.as_bytes()[j - 1] {
-                0
-            } else {
-                1
-            };
+            let cost = usize::from(string1.as_bytes()[i - 1] != string2.as_bytes()[j - 1]);
             inner_matrix[i][j] = (inner_matrix[i - 1][j - 1] + cost)
                 .min(inner_matrix[i][j - 1] + 1)
                 .min(inner_matrix[i - 1][j] + 1);

--- a/src/string/shortest_palindrome.rs
+++ b/src/string/shortest_palindrome.rs
@@ -51,7 +51,7 @@ pub fn compute_suffix(chars: &[char]) -> Vec<usize> {
         while j > 0 && chars[j] != chars[i] {
             j = suffix[j - 1];
         }
-        suffix[i] = j + if chars[j] == chars[i] { 1 } else { 0 };
+        suffix[i] = j + (chars[j] == chars[i]) as usize;
     }
     suffix
 }
@@ -72,13 +72,13 @@ pub fn compute_suffix(chars: &[char]) -> Vec<usize> {
 /// `reversed[0..=i]`.
 pub fn compute_prefix_match(original: &[char], reversed: &[char], suffix: &[usize]) -> Vec<usize> {
     let mut match_table = vec![0; original.len()];
-    match_table[0] = if original[0] == reversed[0] { 1 } else { 0 };
+    match_table[0] = usize::from(original[0] == reversed[0]);
     for i in 1..original.len() {
         let mut j = match_table[i - 1];
         while j > 0 && reversed[i] != original[j] {
             j = suffix[j - 1];
         }
-        match_table[i] = j + if reversed[i] == original[j] { 1 } else { 0 };
+        match_table[i] = j + usize::from(reversed[i] == original[j]);
     }
     match_table
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`bool_to_int_with_if`](https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if) from the list of from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
