### PR TITLE
style: include `range_plus_one`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ missing_panics_doc = { level = "allow", priority = 1 }
 module_name_repetitions = { level = "allow", priority = 1 }
 must_use_candidate = { level = "allow", priority = 1 }
 needless_pass_by_value = { level = "allow", priority = 1 }
-range_plus_one = { level = "allow", priority = 1 }
 redundant_closure_for_method_calls = { level = "allow", priority = 1 }
 return_self_not_must_use = { level = "allow", priority = 1 }
 semicolon_if_nothing_returned = { level = "allow", priority = 1 }

--- a/src/ciphers/transposition.rs
+++ b/src/ciphers/transposition.rs
@@ -5,7 +5,7 @@
 //! original message. The most commonly referred to Transposition Cipher is the
 //! COLUMNAR TRANSPOSITION cipher, which is demonstrated below.
 
-use std::ops::Range;
+use std::ops::RangeInclusive;
 
 /// Encrypts or decrypts a message, using multiple keys. The
 /// encryption is based on the columnar transposition method.
@@ -142,8 +142,8 @@ fn decrypt(mut msg: String, key_order: Vec<usize>) -> String {
 
     split_large.iter_mut().rev().for_each(|key_index| {
         counter -= 1;
-        let range: Range<usize> =
-            ((*key_index * split_size) + counter)..(((*key_index + 1) * split_size) + counter + 1);
+        let range: RangeInclusive<usize> =
+            ((*key_index * split_size) + counter)..=(((*key_index + 1) * split_size) + counter);
 
         let slice: String = msg[range.clone()].to_string();
         indexed_vec.push((*key_index, slice));

--- a/src/data_structures/hash_table.rs
+++ b/src/data_structures/hash_table.rs
@@ -93,7 +93,7 @@ mod tests {
         let mut hash_table = HashTable::new();
         let initial_capacity = hash_table.elements.capacity();
 
-        for i in 0..initial_capacity * 3 / 4 + 1 {
+        for i in 0..=initial_capacity * 3 / 4 {
             hash_table.insert(TestKey(i), TestKey(i + 10));
         }
 

--- a/src/data_structures/lazy_segment_tree.rs
+++ b/src/data_structures/lazy_segment_tree.rs
@@ -235,7 +235,10 @@ mod tests {
     fn check_single_interval_min(array: Vec<i32>) -> TestResult {
         let mut seg_tree = LazySegmentTree::from_vec(&array, min);
         for (i, value) in array.into_iter().enumerate() {
-            let res = seg_tree.query(i..(i + 1));
+            let res = seg_tree.query(Range {
+                start: i,
+                end: i + 1,
+            });
             if res != Some(value) {
                 return TestResult::error(format!("Expected {:?}, got {:?}", Some(value), res));
             }
@@ -247,7 +250,10 @@ mod tests {
     fn check_single_interval_max(array: Vec<i32>) -> TestResult {
         let mut seg_tree = LazySegmentTree::from_vec(&array, max);
         for (i, value) in array.into_iter().enumerate() {
-            let res = seg_tree.query(i..(i + 1));
+            let res = seg_tree.query(Range {
+                start: i,
+                end: i + 1,
+            });
             if res != Some(value) {
                 return TestResult::error(format!("Expected {:?}, got {:?}", Some(value), res));
             }
@@ -259,7 +265,10 @@ mod tests {
     fn check_single_interval_sum(array: Vec<i32>) -> TestResult {
         let mut seg_tree = LazySegmentTree::from_vec(&array, max);
         for (i, value) in array.into_iter().enumerate() {
-            let res = seg_tree.query(i..(i + 1));
+            let res = seg_tree.query(Range {
+                start: i,
+                end: i + 1,
+            });
             if res != Some(value) {
                 return TestResult::error(format!("Expected {:?}, got {:?}", Some(value), res));
             }

--- a/src/dynamic_programming/fibonacci.rs
+++ b/src/dynamic_programming/fibonacci.rs
@@ -226,7 +226,7 @@ fn get_pisano_sequence_and_period(m: i64) -> (i128, Vec<i128>) {
     let mut pisano_sequence: Vec<i128> = vec![a, b];
 
     // Iterating through all the fib numbers to get the sequence
-    for _i in 0..(m * m) + 1 {
+    for _i in 0..=(m * m) {
         let c = (a + b) % m as i128;
 
         // adding number into the sequence

--- a/src/general/mex.rs
+++ b/src/general/mex.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeSet;
 /// O(nlog(n)) implementation
 pub fn mex_using_set(arr: &[i64]) -> i64 {
     let mut s: BTreeSet<i64> = BTreeSet::new();
-    for i in 0..arr.len() + 1 {
+    for i in 0..=arr.len() {
         s.insert(i as i64);
     }
     for x in arr {

--- a/src/graph/bipartite_matching.rs
+++ b/src/graph/bipartite_matching.rs
@@ -45,13 +45,13 @@ impl BipartiteMatching {
     // Note: It does not modify self.mt1, it only works on self.mt2
     pub fn kuhn(&mut self) {
         self.mt2 = vec![-1; self.num_vertices_grp2 + 1];
-        for v in 1..self.num_vertices_grp1 + 1 {
+        for v in 1..=self.num_vertices_grp1 {
             self.used = vec![false; self.num_vertices_grp1 + 1];
             self.try_kuhn(v);
         }
     }
     pub fn print_matching(&self) {
-        for i in 1..self.num_vertices_grp2 + 1 {
+        for i in 1..=self.num_vertices_grp2 {
             if self.mt2[i] == -1 {
                 continue;
             }
@@ -115,7 +115,7 @@ impl BipartiteMatching {
         let mut dist = vec![i32::MAX; self.num_vertices_grp1 + 1];
         let mut res = 0;
         while self.bfs(&mut dist) {
-            for u in 1..self.num_vertices_grp1 + 1 {
+            for u in 1..=self.num_vertices_grp1 {
                 if self.mt1[u] == 0 && self.dfs(u as i32, &mut dist) {
                     res += 1;
                 }

--- a/src/machine_learning/cholesky.rs
+++ b/src/machine_learning/cholesky.rs
@@ -4,7 +4,7 @@ pub fn cholesky(mat: Vec<f64>, n: usize) -> Vec<f64> {
     }
     let mut res = vec![0.0; mat.len()];
     for i in 0..n {
-        for j in 0..(i + 1) {
+        for j in 0..=i {
             let mut s = 0.0;
             for k in 0..j {
                 s += res[i * n + k] * res[j * n + k];

--- a/src/math/area_under_curve.rs
+++ b/src/math/area_under_curve.rs
@@ -12,7 +12,7 @@ pub fn area_under_curve(start: f64, end: f64, func: fn(f64) -> f64, step_count: 
     let mut fx1 = func(start);
     let mut fx2: f64;
 
-    for eval_point in (1..step_count + 1).map(|x| (x as f64 * step_length) + start) {
+    for eval_point in (1..=step_count).map(|x| (x as f64 * step_length) + start) {
         fx2 = func(eval_point);
         area += (fx2 + fx1).abs() * step_length * 0.5;
         fx1 = fx2;

--- a/src/math/factors.rs
+++ b/src/math/factors.rs
@@ -6,7 +6,7 @@
 pub fn factors(number: u64) -> Vec<u64> {
     let mut factors: Vec<u64> = Vec::new();
 
-    for i in 1..((number as f64).sqrt() as u64 + 1) {
+    for i in 1..=((number as f64).sqrt() as u64) {
         if number % i == 0 {
             factors.push(i);
             if i != number / i {

--- a/src/math/gaussian_elimination.rs
+++ b/src/math/gaussian_elimination.rs
@@ -38,7 +38,7 @@ fn echelon(matrix: &mut [Vec<f32>], i: usize, j: usize) {
     if matrix[i][i] == 0f32 {
     } else {
         let factor = matrix[j + 1][i] / matrix[i][i];
-        (i..size + 1).for_each(|k| {
+        (i..=size).for_each(|k| {
             matrix[j + 1][k] -= factor * matrix[i][k];
         });
     }
@@ -48,9 +48,9 @@ fn eliminate(matrix: &mut [Vec<f32>], i: usize) {
     let size = matrix.len();
     if matrix[i][i] == 0f32 {
     } else {
-        for j in (1..i + 1).rev() {
+        for j in (1..=i).rev() {
             let factor = matrix[j - 1][i] / matrix[i][i];
-            for k in (0..size + 1).rev() {
+            for k in (0..=size).rev() {
                 matrix[j - 1][k] -= factor * matrix[i][k];
             }
         }

--- a/src/math/pascal_triangle.rs
+++ b/src/math/pascal_triangle.rs
@@ -12,7 +12,7 @@
 pub fn pascal_triangle(num_rows: i32) -> Vec<Vec<i32>> {
     let mut ans: Vec<Vec<i32>> = vec![];
 
-    for i in 1..num_rows + 1 {
+    for i in 1..=num_rows {
         let mut vec: Vec<i32> = vec![1];
 
         let mut res: i32 = 1;

--- a/src/math/perfect_numbers.rs
+++ b/src/math/perfect_numbers.rs
@@ -14,7 +14,7 @@ pub fn perfect_numbers(max: usize) -> Vec<usize> {
     let mut result: Vec<usize> = Vec::new();
 
     // It is not known if there are any odd perfect numbers, so we go around all the numbers.
-    for i in 1..max + 1 {
+    for i in 1..=max {
         if is_perfect_number(i) {
             result.push(i);
         }

--- a/src/math/prime_numbers.rs
+++ b/src/math/prime_numbers.rs
@@ -4,7 +4,7 @@ pub fn prime_numbers(max: usize) -> Vec<usize> {
     if max >= 2 {
         result.push(2)
     }
-    for i in (3..max + 1).step_by(2) {
+    for i in (3..=max).step_by(2) {
         let stop: usize = (i as f64).sqrt() as usize + 1;
         let mut status = true;
 

--- a/src/number_theory/compute_totient.rs
+++ b/src/number_theory/compute_totient.rs
@@ -17,7 +17,7 @@ pub fn compute_totient(n: i32) -> vec::Vec<i32> {
     }
 
     // Compute other Phi values
-    for p in 2..n + 1 {
+    for p in 2..=n {
         // If phi[p] is not computed already,
         // then number p is prime
         if phi[(p) as usize] == p {
@@ -27,7 +27,7 @@ pub fn compute_totient(n: i32) -> vec::Vec<i32> {
 
             // Update phi values of all
             // multiples of p
-            for i in ((2 * p)..n + 1).step_by(p as usize) {
+            for i in ((2 * p)..=n).step_by(p as usize) {
                 phi[(i) as usize] = (phi[i as usize] / p) * (p - 1);
             }
         }

--- a/src/sorting/binary_insertion_sort.rs
+++ b/src/sorting/binary_insertion_sort.rs
@@ -22,7 +22,7 @@ pub fn binary_insertion_sort<T: Ord + Clone>(arr: &mut [T]) {
         let key = arr[i].clone();
         let index = _binary_search(&arr[..i], &key);
 
-        arr[index..i + 1].rotate_right(1);
+        arr[index..=i].rotate_right(1);
         arr[index] = key;
     }
 }

--- a/src/sorting/pancake_sort.rs
+++ b/src/sorting/pancake_sort.rs
@@ -17,8 +17,8 @@ where
             .map(|(idx, _)| idx)
             .unwrap();
         if max_index != i {
-            arr[0..max_index + 1].reverse();
-            arr[0..i + 1].reverse();
+            arr[0..=max_index].reverse();
+            arr[0..=i].reverse();
         }
     }
     arr.to_vec()

--- a/src/sorting/quick_sort_3_ways.rs
+++ b/src/sorting/quick_sort_3_ways.rs
@@ -8,7 +8,7 @@ fn _quick_sort_3_ways<T: Ord>(arr: &mut [T], lo: usize, hi: usize) {
     }
 
     let mut rng = rand::rng();
-    arr.swap(lo, rng.random_range(lo..hi + 1));
+    arr.swap(lo, rng.random_range(lo..=hi));
 
     let mut lt = lo; // arr[lo+1, lt] < v
     let mut gt = hi + 1; // arr[gt, r] > v

--- a/src/sorting/sort_utils.rs
+++ b/src/sorting/sort_utils.rs
@@ -8,7 +8,7 @@ pub fn generate_random_vec(n: u32, range_l: i32, range_r: i32) -> Vec<i32> {
     let mut count = n;
 
     while count > 0 {
-        arr.push(rng.random_range(range_l..range_r + 1));
+        arr.push(rng.random_range(range_l..=range_r));
         count -= 1;
     }
 

--- a/src/string/manacher.rs
+++ b/src/string/manacher.rs
@@ -69,7 +69,7 @@ pub fn manacher(s: String) -> String {
         .map(|(idx, _)| idx)
         .unwrap();
     let radius_of_max = (length_of_palindrome[center_of_max] - 1) / 2;
-    let answer = &chars[(center_of_max - radius_of_max)..(center_of_max + radius_of_max + 1)]
+    let answer = &chars[(center_of_max - radius_of_max)..=(center_of_max + radius_of_max)]
         .iter()
         .collect::<String>();
     answer.replace('#', "")


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`include_range_plus_one`](https://rust-lang.github.io/rust-clippy/master/index.html#include_range_plus_one) from the list of from the list of suppressed lints.

I am not fully happy with the changes in [`https://github.com/TheAlgorithms/Rust/blob/8049c34fdeb72bd0b0ef455e0fb5c9ca9c3d5e19/src/data_structures/lazy_segment_tree.rs`](https://github.com/TheAlgorithms/Rust/blob/8049c34fdeb72bd0b0ef455e0fb5c9ca9c3d5e19/src/data_structures/lazy_segment_tree.rs).

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
