### PR TITLE
style: include `unnecessary_map_or`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,6 @@ cargo_common_metadata = { level = "allow", priority = 1 }
 # style-lints:
 doc_lazy_continuation = { level = "allow", priority = 1 }
 needless_return = { level = "allow", priority = 1 }
-unnecessary_map_or = { level = "allow", priority = 1 }
 # complexity-lints
 needless_lifetimes = { level = "allow", priority = 1 }
 precedence = { level = "allow", priority = 1 }

--- a/src/graph/astar.rs
+++ b/src/graph/astar.rs
@@ -62,7 +62,7 @@ pub fn astar<V: Ord + Copy, E: Ord + Copy + Add<Output = E> + Zero>(
             let real_weight = real_weight + weight;
             if weights
                 .get(&next)
-                .map_or(true, |&weight| real_weight < weight)
+                .is_none_or(|&weight| real_weight < weight)
             {
                 // current allows us to reach next with lower weight (or at all)
                 // add next to the front


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`unnecessary_map_or`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or) from the list of from the list of suppressed lints.

Continuation of #743. Related to #871.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
