### PR TITLE
Added move_to_front_encoding implementation

### DIFF
--- a/src/compression/mod.rs
+++ b/src/compression/mod.rs
@@ -1,3 +1,5 @@
+mod move_to_front;
 mod run_length_encoding;
 
+pub use self::move_to_front::{move_to_front_decode, move_to_front_encode};
 pub use self::run_length_encoding::{run_length_decode, run_length_encode};

--- a/src/compression/move_to_front.rs
+++ b/src/compression/move_to_front.rs
@@ -1,0 +1,56 @@
+// https://en.wikipedia.org/wiki/Move-to-front_transform
+
+pub fn move_to_front_encode(text: &str) -> Vec<u8> {
+    dbg!(text);
+    let mut char_table: Vec<char> = (0..=255).map(|ch| ch as u8 as char).collect();
+    let mut result = Vec::new();
+
+    for ch in text.chars() {
+        if let Some(position) = char_table.iter().position(|&x| x == ch) {
+            result.push(position as u8);
+            char_table.remove(position);
+            char_table.insert(0, ch);
+        }
+    }
+
+    result
+}
+
+pub fn move_to_front_decode(encoded: &[u8]) -> String {
+    let mut char_table: Vec<char> = (0..=255).map(|ch| ch as u8 as char).collect();
+    let mut result = String::new();
+
+    for &pos in encoded {
+        let ch = char_table[pos as usize];
+        result.push(ch);
+        char_table.remove(pos as usize);
+        char_table.insert(0, ch);
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_move_to_front_encode() {
+        assert_eq!(move_to_front_encode(""), []);
+        assert_eq!(move_to_front_encode("@"), [64]);
+        assert_eq!(move_to_front_encode("aaba"), [97, 0, 98, 1]);
+        assert_eq!(move_to_front_encode("aZ!"), [97, 91, 35]);
+        assert_eq!(move_to_front_encode("banana"), [98, 98, 110, 1, 1, 1]);
+        assert_eq!(move_to_front_encode("\0\n\t"), [0, 10, 10]);
+    }
+
+    #[test]
+    fn test_move_to_front_decode() {
+        assert_eq!(move_to_front_decode(&[]), "");
+        assert_eq!(move_to_front_decode(&[64]), "@");
+        assert_eq!(move_to_front_decode(&[97, 0, 98, 1]), "aaba");
+        assert_eq!(move_to_front_decode(&[97, 91, 35]), "aZ!");
+        assert_eq!(move_to_front_decode(&[98, 98, 110, 1, 1, 1]), "banana");
+        assert_eq!(move_to_front_decode(&[0, 10, 10]), "\0\n\t");
+    }
+}


### PR DESCRIPTION
## **Description**  

This PR adds the **Move-To-Front (MTF) Encoding** algorithm under the **compression** category.  

### **Algorithm Overview**  
Move-To-Front (MTF) Encoding is a lossless data compression algorithm that replaces each character with its position in a dynamically updated list. Every time a character is accessed, it moves to the front of the list. This technique is commonly used as a preprocessing step before further entropy encoding, such as Burrows-Wheeler Transform (BWT).  

For more details: [[Move-To-Front Transform - Wikipedia](https://en.wikipedia.org/wiki/Move-to-front_transform)](https://en.wikipedia.org/wiki/Move-to-front_transform)  

### **Implementation Details**  
- Uses a **Vec<u8>** as a lookup queue for efficient front insertions.  
- Implements both **encoding** and **decoding** functions.  
- Includes **unit tests** to verify correctness.  

## **Type of Change**  
- [x] **New feature** (non-breaking change which adds functionality)  

## **Checklist**  

- [x] I ran the following commands using the latest version of **rust nightly**.  
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.  
- [x] I ran `cargo fmt` just before my last commit.  
- [x] I ran `cargo test` just before my last commit and all tests passed.  
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).  
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.  
- [x] I checked `CONTRIBUTING.md`, and my code follows its guidelines.  