### PR TITLE
chore: suppress new clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ unreadable_literal = { level = "allow", priority = 1 }
 unused_self = { level = "allow", priority = 1 }
 used_underscore_binding = { level = "allow", priority = 1 }
 ref_option = { level = "allow", priority = 1 }
+unnecessary_semicolon = { level = "allow", priority = 1 }
 # restriction-lints:
 absolute_paths = { level = "allow", priority = 1 }
 arithmetic_side_effects = { level = "allow", priority = 1 }
@@ -142,6 +143,7 @@ unused_trait_names = { level = "allow", priority = 1 }
 used_underscore_items = { level = "allow", priority = 1 }
 arbitrary_source_item_ordering = { level = "allow", priority = 1 }
 map_with_unused_argument_over_ranges = { level = "allow", priority = 1 }
+precedence_bits = { level = "allow", priority = 1 }
 # nursery-lints:
 branches_sharing_code = { level = "allow", priority = 1 }
 cognitive_complexity = { level = "allow", priority = 1 }
@@ -162,6 +164,8 @@ cargo_common_metadata = { level = "allow", priority = 1 }
 # style-lints:
 doc_lazy_continuation = { level = "allow", priority = 1 }
 needless_return = { level = "allow", priority = 1 }
+doc_overindented_list_items = { level = "allow", priority = 1 }
 # complexity-lints
 needless_lifetimes = { level = "allow", priority = 1 }
 precedence = { level = "allow", priority = 1 }
+manual_div_ceil = { level = "allow", priority = 1 }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR suppresses new clippy lints (cf. [logs](https://github.com/TheAlgorithms/Rust/actions/runs/14371434231/job/40295111895)).

Similar to:
- #754
- #755
- #845
- #865
- #871
## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
