### PR TITLE
Improve normalize in karatsuba_multiplication implementation

### DIFF
--- a/src/math/karatsuba_multiplication.rs
+++ b/src/math/karatsuba_multiplication.rs
@@ -35,8 +35,9 @@ fn _multiply(num1: i128, num2: i128) -> i128 {
 }
 
 fn normalize(mut a: String, n: usize) -> String {
-    for (counter, _) in (a.len()..n).enumerate() {
-        a.insert(counter, '0');
+    let padding = n.saturating_sub(a.len());
+    if padding > 0 {
+        a.insert_str(0, &"0".repeat(padding));
     }
     a
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Refactor `normalize` in `karatsuba_multiplication.rs` to improve performance and readability.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [ ] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [ ] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
