### PR TITLE
style: include `manual_midpoint`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ used_underscore_binding = { level = "allow", priority = 1 }
 ref_option = { level = "allow", priority = 1 }
 unnecessary_semicolon = { level = "allow", priority = 1 }
 elidable_lifetime_names = { level = "allow", priority = 1 }
-manual_midpoint = { level = "allow", priority = 1 }
 # restriction-lints:
 absolute_paths = { level = "allow", priority = 1 }
 arithmetic_side_effects = { level = "allow", priority = 1 }

--- a/src/math/interquartile_range.rs
+++ b/src/math/interquartile_range.rs
@@ -13,7 +13,7 @@ pub fn find_median(numbers: &[f64]) -> f64 {
     let mid = length / 2;
 
     if length % 2 == 0 {
-        (numbers[mid - 1] + numbers[mid]) / 2.0
+        f64::midpoint(numbers[mid - 1], numbers[mid])
     } else {
         numbers[mid]
     }

--- a/src/math/perfect_square.rs
+++ b/src/math/perfect_square.rs
@@ -18,7 +18,7 @@ pub fn perfect_square_binary_search(n: i32) -> bool {
     let mut right = n;
 
     while left <= right {
-        let mid = (left + right) / 2;
+        let mid = i32::midpoint(left, right);
         let mid_squared = mid * mid;
 
         match mid_squared.cmp(&n) {


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`manual_midpoint`](https://rust-lang.github.io/rust-clippy/stable/index.html#manual_midpoint) from the list of suppressed lints. Continuation of #883.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
