### PR TITLE
style: include `string_to_string`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,6 @@ used_underscore_items = { level = "allow", priority = 1 }
 arbitrary_source_item_ordering = { level = "allow", priority = 1 }
 map_with_unused_argument_over_ranges = { level = "allow", priority = 1 }
 precedence_bits = { level = "allow", priority = 1 }
-string_to_string = { level = "allow", priority = 1 }
 # nursery-lints:
 branches_sharing_code = { level = "allow", priority = 1 }
 cognitive_complexity = { level = "allow", priority = 1 }

--- a/src/ciphers/transposition.rs
+++ b/src/ciphers/transposition.rs
@@ -161,7 +161,7 @@ fn decrypt(mut msg: String, key_order: Vec<usize>) -> String {
 
     for key in key_order {
         if let Some((_, column)) = indexed_vec.iter().find(|(key_index, _)| key_index == &key) {
-            decrypted_vec.push(column.to_string());
+            decrypted_vec.push(column.clone());
         }
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`string_to_string`](https://rust-lang.github.io/rust-clippy/stable/index.html#string_to_string) from the list of suppressed lints. Continuation of #883.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
