### PR TITLE
style: include `elidable_lifetime_names`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ unused_self = { level = "allow", priority = 1 }
 used_underscore_binding = { level = "allow", priority = 1 }
 ref_option = { level = "allow", priority = 1 }
 unnecessary_semicolon = { level = "allow", priority = 1 }
-elidable_lifetime_names = { level = "allow", priority = 1 }
 # restriction-lints:
 absolute_paths = { level = "allow", priority = 1 }
 arithmetic_side_effects = { level = "allow", priority = 1 }

--- a/src/data_structures/binary_search_tree.rs
+++ b/src/data_structures/binary_search_tree.rs
@@ -184,7 +184,7 @@ where
     stack: Vec<&'a BinarySearchTree<T>>,
 }
 
-impl<'a, T> BinarySearchTreeIter<'a, T>
+impl<T> BinarySearchTreeIter<'_, T>
 where
     T: Ord,
 {

--- a/src/data_structures/veb_tree.rs
+++ b/src/data_structures/veb_tree.rs
@@ -221,7 +221,7 @@ impl<'a> VebTreeIter<'a> {
     }
 }
 
-impl<'a> Iterator for VebTreeIter<'a> {
+impl Iterator for VebTreeIter<'_> {
     type Item = u32;
 
     fn next(&mut self) -> Option<u32> {

--- a/src/math/random.rs
+++ b/src/math/random.rs
@@ -107,7 +107,7 @@ impl PCG32 {
     }
 }
 
-impl<'a> Iterator for IterMut<'a> {
+impl Iterator for IterMut<'_> {
     type Item = u32;
     fn next(&mut self) -> Option<Self::Item> {
         Some(self.pcg.get_u32())


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`elidable_lifetime_names`](https://rust-lang.github.io/rust-clippy/stable/index.html#elidable_lifetime_names) from the list of suppressed lints. Continuation of #883.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
