### PR TITLE
style: include `enum_glob_use`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ cast_precision_loss = { level = "allow", priority = 1 }
 cast_sign_loss = { level = "allow", priority = 1 }
 cloned_instead_of_copied = { level = "allow", priority = 1 }
 doc_markdown = { level = "allow", priority = 1 }
-enum_glob_use = { level = "allow", priority = 1 }
 explicit_deref_methods = { level = "allow", priority = 1 }
 explicit_iter_loop = { level = "allow", priority = 1 }
 float_cmp = { level = "allow", priority = 1 }

--- a/src/sorting/dutch_national_flag_sort.rs
+++ b/src/sorting/dutch_national_flag_sort.rs
@@ -11,7 +11,7 @@ pub enum Colors {
     White, //  | Define the three colors of the Dutch Flag: 🇳🇱
     Blue,  // /
 }
-use Colors::*;
+use Colors::{Blue, Red, White};
 
 // Algorithm implementation
 pub fn dutch_national_flag_sort(mut sequence: Vec<Colors>) -> Vec<Colors> {


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`enum_glob_use`](https://rust-lang.github.io/rust-clippy/stable/index.html#enum_glob_use) from the list of suppressed lints. Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
