### PR TITLE
style: include `needless_lifetimes`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,5 @@ doc_lazy_continuation = { level = "allow", priority = 1 }
 needless_return = { level = "allow", priority = 1 }
 doc_overindented_list_items = { level = "allow", priority = 1 }
 # complexity-lints
-needless_lifetimes = { level = "allow", priority = 1 }
 precedence = { level = "allow", priority = 1 }
 manual_div_ceil = { level = "allow", priority = 1 }


### PR DESCRIPTION
# Pull Request Template

## Description
This PR removes the [`needless_lifetimes`](https://rust-lang.github.io/rust-clippy/stable/index.html#needless_lifetimes) from the list of suppressed lints. Continuation of #845.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
