### PR TITLE
chore: suppress new clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ manual_assert = { level = "allow", priority = 1 }
 manual_let_else = { level = "allow", priority = 1 }
 manual_string_new = { level = "allow", priority = 1 }
 many_single_char_names = { level = "allow", priority = 1 }
-match_on_vec_items = { level = "allow", priority = 1 }
 match_wildcard_for_single_variants = { level = "allow", priority = 1 }
 missing_errors_doc = { level = "allow", priority = 1 }
 missing_fields_in_debug = { level = "allow", priority = 1 }
@@ -69,6 +68,7 @@ used_underscore_binding = { level = "allow", priority = 1 }
 ref_option = { level = "allow", priority = 1 }
 unnecessary_semicolon = { level = "allow", priority = 1 }
 ignore_without_reason = { level = "allow", priority = 1 }
+needless_for_each = { level = "allow", priority = 1 }
 # restriction-lints:
 absolute_paths = { level = "allow", priority = 1 }
 arithmetic_side_effects = { level = "allow", priority = 1 }
@@ -169,3 +169,5 @@ doc_overindented_list_items = { level = "allow", priority = 1 }
 # complexity-lints
 precedence = { level = "allow", priority = 1 }
 manual_div_ceil = { level = "allow", priority = 1 }
+# perf-lints
+cloned_ref_to_slice_refs = { level = "allow", priority = 1 }

--- a/src/data_structures/avl_tree.rs
+++ b/src/data_structures/avl_tree.rs
@@ -85,7 +85,7 @@ impl<T: Ord> AVLTree<T> {
     }
 
     /// Returns an iterator that visits the nodes in the tree in order.
-    fn node_iter(&self) -> NodeIter<T> {
+    fn node_iter(&self) -> NodeIter<'_, T> {
         let cap = self.root.as_ref().map_or(0, |n| n.height);
         let mut node_iter = NodeIter {
             stack: Vec::with_capacity(cap),
@@ -100,7 +100,7 @@ impl<T: Ord> AVLTree<T> {
     }
 
     /// Returns an iterator that visits the values in the tree in ascending order.
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             node_iter: self.node_iter(),
         }

--- a/src/data_structures/binary_search_tree.rs
+++ b/src/data_structures/binary_search_tree.rs
@@ -188,7 +188,7 @@ impl<T> BinarySearchTreeIter<'_, T>
 where
     T: Ord,
 {
-    pub fn new(tree: &BinarySearchTree<T>) -> BinarySearchTreeIter<T> {
+    pub fn new(tree: &BinarySearchTree<T>) -> BinarySearchTreeIter<'_, T> {
         let mut iter = BinarySearchTreeIter { stack: vec![tree] };
         iter.stack_push_left();
         iter

--- a/src/data_structures/probabilistic/bloom_filter.rs
+++ b/src/data_structures/probabilistic/bloom_filter.rs
@@ -21,6 +21,7 @@ pub trait BloomFilter<Item: Hash> {
 /// When looking for an item, we hash its value and retrieve the boolean at index `hash(item) % CAPACITY`
 /// If it's `false` it's absolutely sure the item isn't present
 /// If it's `true` the item may be present, or maybe another one produces the same hash
+#[allow(dead_code)]
 #[derive(Debug)]
 struct BasicBloomFilter<const CAPACITY: usize> {
     vec: [bool; CAPACITY],

--- a/src/data_structures/treap.rs
+++ b/src/data_structures/treap.rs
@@ -85,7 +85,7 @@ impl<T: Ord> Treap<T> {
     }
 
     /// Returns an iterator that visits the nodes in the tree in order.
-    fn node_iter(&self) -> NodeIter<T> {
+    fn node_iter(&self) -> NodeIter<'_, T> {
         let mut node_iter = NodeIter { stack: Vec::new() };
         // Initialize stack with path to leftmost child
         let mut child = &self.root;
@@ -97,7 +97,7 @@ impl<T: Ord> Treap<T> {
     }
 
     /// Returns an iterator that visits the values in the tree in ascending order.
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             node_iter: self.node_iter(),
         }

--- a/src/data_structures/veb_tree.rs
+++ b/src/data_structures/veb_tree.rs
@@ -58,7 +58,7 @@ impl VebTree {
         self.max
     }
 
-    pub fn iter(&self) -> VebTreeIter {
+    pub fn iter(&self) -> VebTreeIter<'_> {
         VebTreeIter::new(self)
     }
 

--- a/src/general/genetic.rs
+++ b/src/general/genetic.rs
@@ -36,6 +36,7 @@ pub trait SelectionStrategy<Rng: rand::Rng> {
 
 /// A roulette wheel selection strategy
 /// https://en.wikipedia.org/wiki/Fitness_proportionate_selection
+#[allow(dead_code)]
 pub struct RouletteWheel<Rng: rand::Rng> {
     rng: Rng,
 }
@@ -84,6 +85,7 @@ impl<Rng: rand::Rng> SelectionStrategy<Rng> for RouletteWheel<Rng> {
     }
 }
 
+#[allow(dead_code)]
 pub struct Tournament<const K: usize, Rng: rand::Rng> {
     rng: Rng,
 }

--- a/src/math/random.rs
+++ b/src/math/random.rs
@@ -102,7 +102,7 @@ impl PCG32 {
     pub fn get_state(&self) -> u64 {
         self.state
     }
-    pub fn iter_mut(&mut self) -> IterMut {
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
         IterMut { pcg: self }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR suppresses new clippy lints and resolved new errors.
Similar to:
- #754
- #845
- #865
- #871
- #877
- #883
- #895
## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
