### PR TITLE
Fix/heap corruption

### DIFF
--- a/src/data_structures/floyds_algorithm.rs
+++ b/src/data_structures/floyds_algorithm.rs
@@ -91,5 +91,12 @@ mod tests {
 
         assert!(has_cycle(&linked_list));
         assert_eq!(detect_cycle(&linked_list), Some(3));
+
+        // Break the cycle before the list is dropped
+        unsafe {
+            if let Some(mut tail) = linked_list.tail {
+                tail.as_mut().next = None;
+            }
+        }
     }
 }

--- a/src/general/huffman_encoding.rs
+++ b/src/general/huffman_encoding.rs
@@ -187,7 +187,7 @@ impl HuffmanEncoding {
         self.num_bits += data.bits as u64;
     }
 
-    #[inline(always)]
+    #[inline]
     fn get_bit(&self, pos: u64) -> bool {
         (self.data[(pos >> 6) as usize] & (1 << (pos & 63))) != 0
     }

--- a/src/general/huffman_encoding.rs
+++ b/src/general/huffman_encoding.rs
@@ -78,12 +78,12 @@ pub struct HuffmanDictionary<T> {
 
 impl<T: Clone + Copy + Ord> HuffmanDictionary<T> {
     /// Creates a new Huffman dictionary from alphabet symbols and their frequencies.
-    /// 
+    ///
     /// Returns `None` if the alphabet is empty.
-    /// 
+    ///
     /// # Arguments
     /// * `alphabet` - A slice of tuples containing symbols and their frequencies
-    /// 
+    ///
     /// # Example
     /// ```
     /// # use the_algorithms_rust::general::HuffmanDictionary;

--- a/src/machine_learning/loss_function/kl_divergence_loss.rs
+++ b/src/machine_learning/loss_function/kl_divergence_loss.rs
@@ -16,7 +16,7 @@ pub fn kld_loss(actual: &[f64], predicted: &[f64]) -> f64 {
     let loss: f64 = actual
         .iter()
         .zip(predicted.iter())
-        .map(|(&a, &p)| ((a + eps) * ((a + eps) / (p + eps)).ln()))
+        .map(|(&a, &p)| (a + eps) * ((a + eps) / (p + eps)).ln())
         .sum();
     loss
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Fix heap corruption in Floyd's algorithm tests

## Problem
The test `test_detect_cycle_with_cycle` creates a cycle in a LinkedList but doesn't break it before the list is dropped. This causes heap corruption because the Drop implementation tries to free nodes in an infinite loop, potentially causing double-frees.

## Solution  
Break the cycle at the end of the test by setting the tail's next pointer to None.

## Testing
- Ran `cargo test data_structures` multiple times without heap corruption errors
- Confirmed the fix by running tests with `--test-threads=1` for consistency

Fixes intermittent test failures with "Heap corruption detected" errors.

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x ] I ran bellow commands using the latest version of **rust nightly**.
- [x ] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.

Note I ran cargo clippy --all -- -D warnings locally, and the build fails due to 24 existing warnings/errors (e.g., clippy::manual-is-multiple-of, clippy::needless-range-loop) in unrelated files (ciphers, math, sorting). 

- [x ] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x ] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
