### PR TITLE
style: include `cloned_ref_to_slice_refs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,5 +169,3 @@ doc_overindented_list_items = { level = "allow", priority = 1 }
 # complexity-lints
 precedence = { level = "allow", priority = 1 }
 manual_div_ceil = { level = "allow", priority = 1 }
-# perf-lints
-cloned_ref_to_slice_refs = { level = "allow", priority = 1 }

--- a/src/geometry/ramer_douglas_peucker.rs
+++ b/src/geometry/ramer_douglas_peucker.rs
@@ -104,7 +104,7 @@ mod tests {
 
         assert_eq!(ramer_douglas_peucker(&[], epsilon), vec![]);
         assert_eq!(
-            ramer_douglas_peucker(&[a.clone()], epsilon),
+            ramer_douglas_peucker(std::slice::from_ref(&a), epsilon),
             vec![a.clone()]
         );
         assert_eq!(


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`cloned_ref_to_slice_refs`](https://rust-lang.github.io/rust-clippy/master/index.html#cloned_ref_to_slice_refs) from the list of from the list of suppressed lints.

Continuation of #905.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
