### PR TITLE
style: include `needless_for_each`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ used_underscore_binding = { level = "allow", priority = 1 }
 ref_option = { level = "allow", priority = 1 }
 unnecessary_semicolon = { level = "allow", priority = 1 }
 ignore_without_reason = { level = "allow", priority = 1 }
-needless_for_each = { level = "allow", priority = 1 }
 # restriction-lints:
 absolute_paths = { level = "allow", priority = 1 }
 arithmetic_side_effects = { level = "allow", priority = 1 }

--- a/src/ciphers/transposition.rs
+++ b/src/ciphers/transposition.rs
@@ -42,9 +42,9 @@ pub fn transposition(decrypt_mode: bool, msg: &str, key: &str) -> String {
 
         key_ascii.sort_by_key(|&(index, _)| index);
 
-        key_ascii
-            .into_iter()
-            .for_each(|(_, key)| key_order.push(key.into()));
+        for (_, key) in key_ascii {
+            key_order.push(key.into());
+        }
 
         // Determines whether to encrypt or decrypt the message,
         // and returns the result

--- a/src/general/huffman_encoding.rs
+++ b/src/general/huffman_encoding.rs
@@ -153,8 +153,9 @@ impl<T: Clone + Copy + Ord> HuffmanDictionary<T> {
     }
     pub fn encode(&self, data: &[T]) -> HuffmanEncoding {
         let mut result = HuffmanEncoding::new();
-        data.iter()
-            .for_each(|value| result.add_data(self.alphabet[value]));
+        for value in data.iter() {
+            result.add_data(self.alphabet[value]);
+        }
         result
     }
 }
@@ -237,7 +238,9 @@ mod tests {
     use super::*;
     fn get_frequency(bytes: &[u8]) -> Vec<(u8, u64)> {
         let mut cnts: Vec<u64> = vec![0; 256];
-        bytes.iter().for_each(|&b| cnts[b as usize] += 1);
+        for &b in bytes.iter() {
+            cnts[b as usize] += 1;
+        }
         let mut result = vec![];
         cnts.iter()
             .enumerate()

--- a/src/graph/graph_enumeration.rs
+++ b/src/graph/graph_enumeration.rs
@@ -41,7 +41,9 @@ mod tests {
         let mut result = enumerate_graph(&graph);
         let expected = vec![vec![], vec![2, 3], vec![1, 3, 4], vec![1, 2], vec![2]];
 
-        result.iter_mut().for_each(|v| v.sort_unstable());
+        for v in result.iter_mut() {
+            v.sort_unstable();
+        }
         assert_eq!(result, expected);
     }
 
@@ -55,7 +57,9 @@ mod tests {
         let mut result = enumerate_graph(&graph);
         let expected = vec![vec![], vec![2, 3], vec![1, 3, 4], vec![1, 2], vec![2]];
 
-        result.iter_mut().for_each(|v| v.sort_unstable());
+        for v in result.iter_mut() {
+            v.sort_unstable();
+        }
         assert_eq!(result, expected);
     }
 }

--- a/src/math/fast_fourier_transform.rs
+++ b/src/math/fast_fourier_transform.rs
@@ -192,7 +192,9 @@ mod tests {
         polynomial.append(&mut vec![0.0; 4]);
         let permutation = fast_fourier_transform_input_permutation(polynomial.len());
         let mut fft = fast_fourier_transform(&polynomial, &permutation);
-        fft.iter_mut().for_each(|num| *num *= *num);
+        for num in fft.iter_mut() {
+            *num *= *num;
+        }
         let ifft = inverse_fast_fourier_transform(&fft, &permutation);
         let expected = [1.0, 2.0, 1.0, 4.0, 4.0, 0.0, 4.0, 0.0, 0.0];
         for (x, y) in ifft.iter().zip(expected.iter()) {
@@ -210,7 +212,9 @@ mod tests {
         polynomial.append(&mut vec![0.0f64; n]);
         let permutation = fast_fourier_transform_input_permutation(polynomial.len());
         let mut fft = fast_fourier_transform(&polynomial, &permutation);
-        fft.iter_mut().for_each(|num| *num *= *num);
+        for num in fft.iter_mut() {
+            *num *= *num;
+        }
         let ifft = inverse_fast_fourier_transform(&fft, &permutation);
         let expected = (0..((n << 1) - 1)).map(|i| std::cmp::min(i + 1, (n << 1) - 1 - i) as f64);
         for (&x, y) in ifft.iter().zip(expected) {


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`needless_for_each`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_for_each) from the list of from the list of suppressed lints.

Continuation of #905.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.
