### PR TITLE
style: include `if_not_else`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ doc_markdown = { level = "allow", priority = 1 }
 explicit_deref_methods = { level = "allow", priority = 1 }
 explicit_iter_loop = { level = "allow", priority = 1 }
 float_cmp = { level = "allow", priority = 1 }
-if_not_else = { level = "allow", priority = 1 }
 implicit_clone = { level = "allow", priority = 1 }
 implicit_hasher = { level = "allow", priority = 1 }
 items_after_statements = { level = "allow", priority = 1 }

--- a/src/data_structures/b_tree.rs
+++ b/src/data_structures/b_tree.rs
@@ -68,10 +68,10 @@ impl BTreeProps {
             }
             None => Vec::with_capacity(self.max_keys),
         };
-        let right_children = if !child.is_leaf() {
-            Some(child.children.split_off(self.mid_key_index + 1))
-        } else {
+        let right_children = if child.is_leaf() {
             None
+        } else {
+            Some(child.children.split_off(self.mid_key_index + 1))
         };
         let new_child_node: Node<T> = Node::new(self.degree, Some(right_keys), right_children);
 

--- a/src/graph/lee_breadth_first_search.rs
+++ b/src/graph/lee_breadth_first_search.rs
@@ -47,10 +47,10 @@ pub fn lee(matrix: Vec<Vec<i32>>, source: (usize, usize), destination: (usize, u
         }
     }
 
-    if min_dist != isize::MAX {
-        min_dist
-    } else {
+    if min_dist == isize::MAX {
         -1
+    } else {
+        min_dist
     }
 }
 

--- a/src/math/elliptic_curve.rs
+++ b/src/math/elliptic_curve.rs
@@ -182,10 +182,10 @@ impl<F: Field, const A: i64, const B: i64> Add for EllipticCurve<F, A, B> {
             // mirrored
             Self::infinity()
         } else {
-            let slope = if self.x != p.x {
-                (self.y - p.y) / (self.x - p.x)
-            } else {
+            let slope = if self.x == p.x {
                 ((self.x * self.x).integer_mul(3) + F::from_integer(A)) / self.y.integer_mul(2)
+            } else {
+                (self.y - p.y) / (self.x - p.x)
             };
             let x = slope * slope - self.x - p.x;
             let y = -self.y + slope * (self.x - x);

--- a/src/math/modular_exponential.rs
+++ b/src/math/modular_exponential.rs
@@ -37,11 +37,11 @@ pub fn gcd_extended(a: i64, m: i64) -> (i64, i64, i64) {
 /// Panics if the inverse does not exist (i.e., `b` and `m` are not coprime).
 pub fn mod_inverse(b: i64, m: i64) -> i64 {
     let (gcd, x, _) = gcd_extended(b, m);
-    if gcd != 1 {
-        panic!("Inverse does not exist");
-    } else {
+    if gcd == 1 {
         // Ensure the modular inverse is positive
         (x % m + m) % m
+    } else {
+        panic!("Inverse does not exist");
     }
 }
 

--- a/src/math/trig_functions.rs
+++ b/src/math/trig_functions.rs
@@ -103,11 +103,11 @@ pub fn tan<T: Into<f64> + Copy>(x: T, tol: f64) -> f64 {
     let cos_val = cosine(x, tol);
 
     /* Cover special cases for division */
-    if cos_val != 0f64 {
+    if cos_val == 0f64 {
+        f64::NAN
+    } else {
         let sin_val = sine(x, tol);
         sin_val / cos_val
-    } else {
-        f64::NAN
     }
 }
 
@@ -116,11 +116,11 @@ pub fn cotan<T: Into<f64> + Copy>(x: T, tol: f64) -> f64 {
     let sin_val = sine(x, tol);
 
     /* Cover special cases for division */
-    if sin_val != 0f64 {
+    if sin_val == 0f64 {
+        f64::NAN
+    } else {
         let cos_val = cosine(x, tol);
         cos_val / sin_val
-    } else {
-        f64::NAN
     }
 }
 

--- a/src/sorting/heap_sort.rs
+++ b/src/sorting/heap_sort.rs
@@ -30,10 +30,10 @@ fn build_heap<T: Ord>(arr: &mut [T], is_max_heap: bool) {
 /// * `i` - The index to start fixing the heap violation.
 /// * `is_max_heap` - A boolean indicating whether to maintain a max heap or a min heap.
 fn heapify<T: Ord>(arr: &mut [T], i: usize, is_max_heap: bool) {
-    let comparator: fn(&T, &T) -> Ordering = if !is_max_heap {
-        |a, b| b.cmp(a)
-    } else {
+    let comparator: fn(&T, &T) -> Ordering = if is_max_heap {
         |a, b| a.cmp(b)
+    } else {
+        |a, b| b.cmp(a)
     };
 
     let mut idx = i;

--- a/src/string/z_algorithm.rs
+++ b/src/string/z_algorithm.rs
@@ -103,10 +103,10 @@ fn match_with_z_array<T: Eq>(
         }
     }
 
-    if !only_full_matches {
-        z_array
-    } else {
+    if only_full_matches {
         find_full_matches(&z_array, pattern_size)
+    } else {
+        z_array
     }
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR removes [`if_not_else`](https://rust-lang.github.io/rust-clippy/master/index.html#if_not_else) from the list of from the list of suppressed lints.

Continuation of #743.

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.