### PR TITLE
PR: Implementing Job Sequencing Problem with Deadlines (using Greedy Approach)

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -157,6 +157,7 @@
     * [Two Satisfiability](https://github.com/TheAlgorithms/Rust/blob/master/src/graph/two_satisfiability.rs)
   * Greedy
     * [Stable Matching](https://github.com/TheAlgorithms/Rust/blob/master/src/greedy/stable_matching.rs)
+    * [Job Sequencing](https://github.com/TheAlgorithms/Rust/blob/master/src/greedy/job_sequencing.rs)
   * [Lib](https://github.com/TheAlgorithms/Rust/blob/master/src/lib.rs)
   * Machine Learning
     * [Cholesky](https://github.com/TheAlgorithms/Rust/blob/master/src/machine_learning/cholesky.rs)

--- a/src/greedy/job_sequencing.rs
+++ b/src/greedy/job_sequencing.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 #[derive(Debug, Clone)]
 pub struct Job {
     pub id: String,

--- a/src/greedy/job_sequencing.rs
+++ b/src/greedy/job_sequencing.rs
@@ -1,0 +1,88 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct Job {
+    pub id: String,
+    pub deadline: usize,
+    pub profit: i32,
+}
+
+pub fn job_sequencing(mut jobs: Vec<Job>) -> (Vec<Job>, i32) {
+    if jobs.is_empty() {
+        return (Vec::new(), 0);
+    }
+
+    // Sort by profit (descending)
+    jobs.sort_by(|a, b| b.profit.cmp(&a.profit));
+
+    // Find the maximum deadline
+    let max_deadline = jobs.iter().map(|j| j.deadline).max().unwrap();
+
+    // Track time slots that are filled
+    let mut slots = vec![false; max_deadline];
+    let mut scheduled = Vec::new();
+    let mut total_profit = 0;
+
+    // Schedule each job in the latest available slot before its deadline is reached
+    for job in jobs {
+        for slot in (0..job.deadline.min(max_deadline)).rev() {
+            if !slots[slot] {
+                slots[slot] = true;
+                scheduled.push(job.clone());
+                total_profit += job.profit;
+                break;
+            }
+        }
+    }
+
+    (scheduled, total_profit)
+}
+
+// test algorithm
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        let jobs = vec![
+            Job {
+                id: "J1".to_string(),
+                deadline: 2,
+                profit: 100,
+            },
+            Job {
+                id: "J2".to_string(),
+                deadline: 1,
+                profit: 19,
+            },
+            Job {
+                id: "J3".to_string(),
+                deadline: 2,
+                profit: 27,
+            },
+            Job {
+                id: "J4".to_string(),
+                deadline: 1,
+                profit: 25,
+            },
+            Job {
+                id: "J5".to_string(),
+                deadline: 3,
+                profit: 15,
+            },
+        ];
+
+        let (scheduled, profit) = job_sequencing(jobs);
+
+        assert_eq!(profit, 142);
+        assert_eq!(scheduled.len(), 3);
+    }
+
+    #[test]
+    fn test_empty() {
+        let (scheduled, profit) = job_sequencing(vec![]);
+        assert_eq!(profit, 0);
+        assert!(scheduled.is_empty());
+    }
+}

--- a/src/greedy/mod.rs
+++ b/src/greedy/mod.rs
@@ -1,3 +1,5 @@
+mod job_sequencing;
 mod stable_matching;
 
+pub use self::job_sequencing::job_sequencing;
 pub use self::stable_matching::stable_matching;


### PR DESCRIPTION
# Pull Request

## Description
This Pull Request aims to add a Job Sequencing with Deadlines algorithm using a greedy approach. This algorithm solves the classic problem of scheduling jobs to maximize profit, where each job has:
1. A given deadline (i.e., the latest time by which it must complete to generate a profit value)
2. The said profit value

Algorithm Overview:
We performthe following steps:
1. Sort all jobs based on their profit in a descending order.
2. For each job, we attempt to schedule it in the time slot that is availabe at the latest, before its deadline is reached.
3. If this slot is available, schedule the job or otherwise, skip it.
4. Return the list of scheduled jobs and total profit achieved.

For "n" no. of jobs
Time Complexity: O(n²) 
Space Complexity: O(n)
For more details about the algorithm, see: [Job Sequencing Problem - GeeksforGeeks (https://www.geeksforgeeks.org/dsa/job-sequencing-problem/)

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
