### PR TITLE
search: add search_rotated_sorted_array with tests

### DIFF
--- a/src/searching/mod.rs
+++ b/src/searching/mod.rs
@@ -14,6 +14,7 @@ mod ternary_search;
 mod ternary_search_min_max;
 mod ternary_search_min_max_recursive;
 mod ternary_search_recursive;
+mod search_rotated_sorted_array;
 
 pub use self::binary_search::binary_search;
 pub use self::binary_search_recursive::binary_search_rec;
@@ -33,3 +34,4 @@ pub use self::ternary_search_min_max::ternary_search_min;
 pub use self::ternary_search_min_max_recursive::ternary_search_max_rec;
 pub use self::ternary_search_min_max_recursive::ternary_search_min_rec;
 pub use self::ternary_search_recursive::ternary_search_rec;
+pub use self::search_rotated_sorted_array::search_rotated_sorted_array;

--- a/src/searching/search_rotated_sorted_array.rs
+++ b/src/searching/search_rotated_sorted_array.rs
@@ -1,0 +1,74 @@
+//! Search for a target in a rotated sorted array.
+//!
+//! This implementation returns the index of `target` if present, or `None`.
+//! It assumes the input slice contains distinct elements and was originally
+//! sorted in ascending order before rotation.
+
+/// Searches for `target` in a rotated sorted slice and returns its index.
+///
+/// Time complexity: O(log n)
+pub fn search_rotated_sorted_array<T: Ord>(arr: &[T], target: &T) -> Option<usize> {
+    if arr.is_empty() {
+        return None;
+    }
+
+    let mut left: isize = 0;
+    let mut right: isize = (arr.len() - 1) as isize;
+
+    while left <= right {
+        let mid = left + (right - left) / 2;
+        let mid_usize = mid as usize;
+
+        if &arr[mid_usize] == target {
+            return Some(mid_usize);
+        }
+
+        // Determine which half is normally ordered
+        if arr[left as usize] <= arr[mid_usize] {
+            // Left half is sorted
+            if &arr[left as usize] <= target && target < &arr[mid_usize] {
+                right = mid - 1;
+            } else {
+                left = mid + 1;
+            }
+        } else {
+            // Right half is sorted
+            if &arr[mid_usize] < target && target <= &arr[right as usize] {
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_in_rotated_sorted_array_found_examples() {
+        let arr = vec![4, 5, 6, 7, 0, 1, 2];
+        assert_eq!(search_rotated_sorted_array(&arr, &0), Some(4));
+        assert_eq!(search_rotated_sorted_array(&arr, &4), Some(0));
+        assert_eq!(search_rotated_sorted_array(&arr, &2), Some(6));
+    }
+
+    #[test]
+    fn search_in_rotated_sorted_array_not_found() {
+        let arr = vec![4, 5, 6, 7, 0, 1, 2];
+        assert_eq!(search_rotated_sorted_array(&arr, &3), None);
+    }
+
+    #[test]
+    fn empty_and_single() {
+        let empty: Vec<i32> = vec![];
+        assert_eq!(search_rotated_sorted_array(&empty, &1), None);
+
+        let single = vec![1];
+        assert_eq!(search_rotated_sorted_array(&single, &1), Some(0));
+        assert_eq!(search_rotated_sorted_array(&single, &2), None);
+    }
+}


### PR DESCRIPTION

## Description

- Summary: Implemented `search_rotated_sorted_array` which finds a target in a rotated, ascending-sorted slice and returns `Option<usize>`.
- Motivation: This algorithm complements existing searching implementations by handling arrays that were rotated after sorting.
- Implementation method: A modified binary search that detects which half of the current range is normally ordered and narrows the search into the half that can contain the target. Assumes distinct elements.
- Complexity: O(log n) time, O(1) extra space.
- Notes: If duplicate elements must be supported, additional checks are required and worst-case complexity may degrade.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I ran below commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `CONTRIBUTING.md` and my code follows its guidelines.
