### PR TITLE
Fix typos in src/ciphers/chacha.rs

### DIFF
--- a/src/ciphers/base64.rs
+++ b/src/ciphers/base64.rs
@@ -69,7 +69,7 @@ pub fn base64_decode(data: &str) -> Result<Vec<u8>, (&str, u8)> {
     'decodeloop: loop {
         while collected_bits < 8 {
             if let Some(nextbyte) = databytes.next() {
-                // Finds the first occurence of the latest byte
+                // Finds the first occurrence of the latest byte
                 if let Some(idx) = CHARSET.iter().position(|&x| x == nextbyte) {
                     byte_buffer |= ((idx & 0b00111111) as u16) << (10 - collected_bits);
                     collected_bits += 6;


### PR DESCRIPTION
This PR fixes typos in the file src/ciphers/chacha.rs