### PR TITLE
chore: suppress `needless_range_loop`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ cargo_common_metadata = { level = "allow", priority = 1 }
 doc_lazy_continuation = { level = "allow", priority = 1 }
 needless_return = { level = "allow", priority = 1 }
 doc_overindented_list_items = { level = "allow", priority = 1 }
+needless_range_loop = { level = "allow", priority = 1 }
 # complexity-lints
 precedence = { level = "allow", priority = 1 }
 manual_div_ceil = { level = "allow", priority = 1 }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR suppresses new clippy lints and resolved new errors.
Similar to:
- #754
- #845
- #865
- #871
- #877
- #883
- #895
- #905 
## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
