### PR TITLE
feat: add subarray sum equals k algorithm

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -128,6 +128,7 @@
       * [Heap](https://github.com/TheAlgorithms/Rust/blob/master/src/general/permutations/heap.rs)
       * [Naive](https://github.com/TheAlgorithms/Rust/blob/master/src/general/permutations/naive.rs)
       * [Steinhaus Johnson Trotter](https://github.com/TheAlgorithms/Rust/blob/master/src/general/permutations/steinhaus_johnson_trotter.rs)
+    * [Subarray Sum Equals K](https://github.com/TheAlgorithms/Rust/blob/master/src/general/subarray_sum_equals_k.rs)
     * [Two Sum](https://github.com/TheAlgorithms/Rust/blob/master/src/general/two_sum.rs)
   * Geometry
     * [Closest Points](https://github.com/TheAlgorithms/Rust/blob/master/src/geometry/closest_points.rs)

--- a/src/general/mod.rs
+++ b/src/general/mod.rs
@@ -7,6 +7,7 @@ mod kadane_algorithm;
 mod kmeans;
 mod mex;
 mod permutations;
+mod subarray_sum_equals_k;
 mod two_sum;
 
 pub use self::convex_hull::convex_hull_graham;
@@ -22,4 +23,5 @@ pub use self::mex::mex_using_sort;
 pub use self::permutations::{
     heap_permute, permute, permute_unique, steinhaus_johnson_trotter_permute,
 };
+pub use self::subarray_sum_equals_k::subarray_sum_equals_k;
 pub use self::two_sum::two_sum;

--- a/src/general/subarray_sum_equals_k.rs
+++ b/src/general/subarray_sum_equals_k.rs
@@ -1,0 +1,77 @@
+use std::collections::HashMap;
+
+/// Counts the number of contiguous subarrays that sum to exactly k.
+///
+/// # Parameters
+///
+/// - `nums`: A slice of integers
+/// - `k`: The target sum
+///
+/// # Returns
+///
+/// The number of contiguous subarrays with sum equal to k.
+///
+/// # Complexity
+///
+/// - Time: O(n)
+/// - Space: O(n)
+
+pub fn subarray_sum_equals_k(nums: &[i32], k: i32) -> i32 {
+    let mut prefix_sum_count: HashMap<i64, i32> = HashMap::new();
+    prefix_sum_count.insert(0, 1);
+
+    let mut prefix_sum: i64 = 0;
+    let mut count = 0;
+
+    for &num in nums {
+        prefix_sum += num as i64;
+        let target = prefix_sum - k as i64;
+
+        if let Some(&freq) = prefix_sum_count.get(&target) {
+            count += freq;
+        }
+
+        *prefix_sum_count.entry(prefix_sum).or_insert(0) += 1;
+    }
+
+    count
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        assert_eq!(subarray_sum_equals_k(&[1, 1, 1], 2), 2);
+        assert_eq!(subarray_sum_equals_k(&[1, 2, 3], 3), 2);
+    }
+
+    #[test]
+    fn test_single_element() {
+        assert_eq!(subarray_sum_equals_k(&[1], 1), 1);
+        assert_eq!(subarray_sum_equals_k(&[1], 0), 0);
+    }
+
+    #[test]
+    fn test_empty() {
+        assert_eq!(subarray_sum_equals_k(&[], 0), 0);
+        assert_eq!(subarray_sum_equals_k(&[], 5), 0);
+    }
+
+    #[test]
+    fn test_negative_numbers() {
+        assert_eq!(subarray_sum_equals_k(&[-1, -1, 1], 0), 1);
+        assert_eq!(subarray_sum_equals_k(&[1, -1, 0], 0), 3);
+    }
+
+    #[test]
+    fn test_no_match() {
+        assert_eq!(subarray_sum_equals_k(&[1, 2, 3], 10), 0);
+    }
+
+    #[test]
+    fn test_multiple_matches() {
+        assert_eq!(subarray_sum_equals_k(&[1, 0, 1, 0, 1], 1), 8);
+    }
+}


### PR DESCRIPTION
## Description

This PR adds an implementation of the "Subarray Sum Equals K" algorithm to the `general` module. The algorithm counts the number of contiguous subarrays that sum to exactly `k`.

**Implementation Method:**
- Uses prefix sum technique with HashMap for O(n) time complexity
- Space complexity: O(n) for the HashMap
- Handles edge cases including empty arrays, negative numbers, and zero sums

**Algorithm Reference:**
This is a classic LeetCode problem (Problem 560). The solution uses the prefix sum approach where we track cumulative sums and check if `prefix_sum - k` exists in our map, which indicates a subarray with sum `k` exists.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `CONTRIBUTING.md` and my code follows its guidelines.