### PR TITLE
fix: prevent null pointer dereference in rb_tree delete_fixup

### DIFF
--- a/src/data_structures/rb_tree.rs
+++ b/src/data_structures/rb_tree.rs
@@ -367,6 +367,12 @@ unsafe fn delete_fixup<K: Ord, V>(tree: &mut RBTree<K, V>, mut parent: *mut RBNo
     let mut sr: *mut RBNode<K, V>;
 
     loop {
+        // rb-tree will keep color balance up to root,
+        // if parent is null, we are done.
+        if parent.is_null() {
+            break;
+        }
+
         /*
          * Loop invariants:
          * - node is black (or null on first iteration)
@@ -646,5 +652,24 @@ mod tests {
         tree.delete(&11);
         let s: String = tree.iter().map(|x| x.value).collect();
         assert_eq!(s, "hlo orl!");
+    }
+
+    #[test]
+    fn delete_edge_case_null_pointer_guard() {
+        let mut tree = RBTree::<i8, i8>::new();
+        tree.insert(4, 4);
+        tree.insert(2, 2);
+        tree.insert(5, 5);
+        tree.insert(0, 0);
+        tree.insert(3, 3);
+        tree.insert(-1, -1);
+        tree.insert(1, 1);
+        tree.insert(-2, -2);
+        tree.insert(6, 6);
+        tree.insert(7, 7);
+        tree.insert(8, 8);
+        tree.delete(&1);
+        tree.delete(&3);
+        tree.delete(&-1);
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Prevent null pointer dereference in rb_tree delete_fixup.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [ ] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [ ] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
