### PR TITLE
Add Binary Coded Decimal algorithm to bit manipulation

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -2,7 +2,7 @@
 
 ## Src
   * Backtracking
-    * [All Combination Of Size K](https://github.com/TheAlgorithms/Rust/blob/master/src/backtracking/all_combination_of_size_k.rs)
+    * [All Combinations of Size K](https://github.com/TheAlgorithms/Rust/blob/master/src/backtracking/all_combination_of_size_k.rs)
     * [Graph Coloring](https://github.com/TheAlgorithms/Rust/blob/master/src/backtracking/graph_coloring.rs)
     * [Hamiltonian Cycle](https://github.com/TheAlgorithms/Rust/blob/master/src/backtracking/hamiltonian_cycle.rs)
     * [Knight Tour](https://github.com/TheAlgorithms/Rust/blob/master/src/backtracking/knight_tour.rs)
@@ -17,6 +17,7 @@
     * [Multiply](https://github.com/TheAlgorithms/Rust/blob/master/src/big_integer/multiply.rs)
     * [Poly1305](https://github.com/TheAlgorithms/Rust/blob/master/src/big_integer/poly1305.rs)
   * Bit Manipulation
+    * [Binary Coded Decimal](https://github.com/TheAlgorithms/Rust/blob/master/src/bit_manipulation/binary_coded_decimal.rs)
     * [Counting Bits](https://github.com/TheAlgorithms/Rust/blob/master/src/bit_manipulation/counting_bits.rs)
     * [Highest Set Bit](https://github.com/TheAlgorithms/Rust/blob/master/src/bit_manipulation/highest_set_bit.rs)
     * [N Bits Gray Code](https://github.com/TheAlgorithms/Rust/blob/master/src/bit_manipulation/n_bits_gray_code.rs)
@@ -104,7 +105,7 @@
     * [Maximal Square](https://github.com/TheAlgorithms/Rust/blob/master/src/dynamic_programming/maximal_square.rs)
     * [Maximum Subarray](https://github.com/TheAlgorithms/Rust/blob/master/src/dynamic_programming/maximum_subarray.rs)
     * [Minimum Cost Path](https://github.com/TheAlgorithms/Rust/blob/master/src/dynamic_programming/minimum_cost_path.rs)
-    * [Optimal Bst](https://github.com/TheAlgorithms/Rust/blob/master/src/dynamic_programming/optimal_bst.rs)
+    * [Optimal BST](https://github.com/TheAlgorithms/Rust/blob/master/src/dynamic_programming/optimal_bst.rs)
     * [Rod Cutting](https://github.com/TheAlgorithms/Rust/blob/master/src/dynamic_programming/rod_cutting.rs)
     * [Smith-Waterman](https://github.com/TheAlgorithms/Rust/blob/master/src/dynamic_programming/smith_waterman.rs)
     * [Snail](https://github.com/TheAlgorithms/Rust/blob/master/src/dynamic_programming/snail.rs)

--- a/src/bit_manipulation/binary_coded_decimal.rs
+++ b/src/bit_manipulation/binary_coded_decimal.rs
@@ -1,0 +1,129 @@
+//! Binary Coded Decimal (BCD) conversion
+//!
+//! This module provides a function to convert decimal integers to Binary Coded Decimal (BCD) format.
+//! In BCD, each decimal digit is represented by its 4-bit binary equivalent.
+//!
+//! # Examples
+//!
+//! ```
+//! use the_algorithms_rust::bit_manipulation::binary_coded_decimal;
+//!
+//! assert_eq!(binary_coded_decimal(12), "0b00010010");
+//! assert_eq!(binary_coded_decimal(987), "0b100110000111");
+//! ```
+
+use std::fmt::Write;
+
+/// Converts a decimal integer to Binary Coded Decimal (BCD) format.
+///
+/// Each digit of the input number is represented by a 4-bit binary value.
+/// Negative numbers are treated as 0.
+///
+/// # Arguments
+///
+/// * `number` - An integer to be converted to BCD format
+///
+/// # Returns
+///
+/// A `String` representing the BCD encoding with "0b" prefix
+///
+/// # Examples
+///
+/// ```
+/// use the_algorithms_rust::bit_manipulation::binary_coded_decimal;
+///
+/// assert_eq!(binary_coded_decimal(0), "0b0000");
+/// assert_eq!(binary_coded_decimal(3), "0b0011");
+/// assert_eq!(binary_coded_decimal(12), "0b00010010");
+/// assert_eq!(binary_coded_decimal(987), "0b100110000111");
+/// assert_eq!(binary_coded_decimal(-5), "0b0000");
+/// ```
+///
+/// # Algorithm
+///
+/// 1. Convert the number to its absolute value (negative numbers become 0)
+/// 2. For each decimal digit:
+///    - Convert the digit to binary
+///    - Pad to 4 bits with leading zeros
+///    - Concatenate to the result
+/// 3. Prepend "0b" to the final binary string
+pub fn binary_coded_decimal(number: i32) -> String {
+    // Handle negative numbers by converting to 0
+    let num = if number < 0 { 0 } else { number };
+
+    // Convert to string to process each digit
+    let digits = num.to_string();
+
+    // Build the BCD string using fold for efficiency
+    let bcd = digits.chars().fold(String::new(), |mut acc, digit| {
+        // Convert char to digit value and format as 4-bit binary
+        let digit_value = digit.to_digit(10).unwrap();
+        write!(acc, "{digit_value:04b}").unwrap();
+        acc
+    });
+
+    format!("0b{bcd}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        assert_eq!(binary_coded_decimal(0), "0b0000");
+    }
+
+    #[test]
+    fn test_single_digit() {
+        assert_eq!(binary_coded_decimal(1), "0b0001");
+        assert_eq!(binary_coded_decimal(2), "0b0010");
+        assert_eq!(binary_coded_decimal(3), "0b0011");
+        assert_eq!(binary_coded_decimal(4), "0b0100");
+        assert_eq!(binary_coded_decimal(5), "0b0101");
+        assert_eq!(binary_coded_decimal(6), "0b0110");
+        assert_eq!(binary_coded_decimal(7), "0b0111");
+        assert_eq!(binary_coded_decimal(8), "0b1000");
+        assert_eq!(binary_coded_decimal(9), "0b1001");
+    }
+
+    #[test]
+    fn test_two_digits() {
+        assert_eq!(binary_coded_decimal(10), "0b00010000");
+        assert_eq!(binary_coded_decimal(12), "0b00010010");
+        assert_eq!(binary_coded_decimal(25), "0b00100101");
+        assert_eq!(binary_coded_decimal(99), "0b10011001");
+    }
+
+    #[test]
+    fn test_three_digits() {
+        assert_eq!(binary_coded_decimal(100), "0b000100000000");
+        assert_eq!(binary_coded_decimal(123), "0b000100100011");
+        assert_eq!(binary_coded_decimal(456), "0b010001010110");
+        assert_eq!(binary_coded_decimal(987), "0b100110000111");
+    }
+
+    #[test]
+    fn test_large_numbers() {
+        assert_eq!(binary_coded_decimal(1234), "0b0001001000110100");
+        assert_eq!(binary_coded_decimal(9999), "0b1001100110011001");
+    }
+
+    #[test]
+    fn test_negative_numbers() {
+        // Negative numbers should be treated as 0
+        assert_eq!(binary_coded_decimal(-1), "0b0000");
+        assert_eq!(binary_coded_decimal(-2), "0b0000");
+        assert_eq!(binary_coded_decimal(-100), "0b0000");
+    }
+
+    #[test]
+    fn test_each_digit_encoding() {
+        // Verify that each digit is encoded correctly in a multi-digit number
+        // 67 should be: 6 (0110) and 7 (0111)
+        assert_eq!(binary_coded_decimal(67), "0b01100111");
+
+        // 305 should be: 3 (0011), 0 (0000), 5 (0101)
+        assert_eq!(binary_coded_decimal(305), "0b001100000101");
+    }
+}

--- a/src/bit_manipulation/mod.rs
+++ b/src/bit_manipulation/mod.rs
@@ -1,3 +1,4 @@
+mod binary_coded_decimal;
 mod counting_bits;
 mod highest_set_bit;
 mod n_bits_gray_code;
@@ -5,6 +6,7 @@ mod reverse_bits;
 mod sum_of_two_integers;
 mod swap_odd_even_bits;
 
+pub use binary_coded_decimal::binary_coded_decimal;
 pub use counting_bits::count_set_bits;
 pub use highest_set_bit::find_highest_set_bit;
 pub use n_bits_gray_code::generate_gray_code;

--- a/src/string/isogram.rs
+++ b/src/string/isogram.rs
@@ -56,7 +56,7 @@ fn count_letters(s: &str) -> Result<HashMap<char, usize>, IsogramError> {
 /// # Return
 ///
 /// - `Ok(true)` if all characters appear only once, or `Ok(false)` if any character appears more than once.
-/// - `Err(IsogramError::NonAlphabeticCharacter) if the input contains any non-alphabetic characters.
+/// - `Err(IsogramError::NonAlphabeticCharacter)` if the input contains any non-alphabetic characters.
 pub fn is_isogram(s: &str) -> Result<bool, IsogramError> {
     let letter_counts = count_letters(s)?;
     Ok(letter_counts.values().all(|&count| count == 1))
@@ -89,7 +89,7 @@ mod tests {
         isogram_sentences: ("The big dwarf only jumps", Ok(true)),
         isogram_french: ("Lampez un fort whisky", Ok(true)),
         isogram_portuguese: ("Velho traduz sim", Ok(true)),
-        isogram_spanis: ("Centrifugadlos", Ok(true)),
+        isogram_spanish: ("Centrifugadlos", Ok(true)),
         invalid_isogram_with_repeated_char: ("hello", Ok(false)),
         invalid_isogram_with_numbers: ("abc123", Err(IsogramError::NonAlphabeticCharacter)),
         invalid_isogram_with_special_char: ("abc!", Err(IsogramError::NonAlphabeticCharacter)),


### PR DESCRIPTION
## Description
Adds the Binary Coded Decimal (BCD) algorithm to the bit manipulation module.

This algorithm converts a decimal integer to Binary Coded Decimal format, where each decimal digit is represented by its 4-bit binary equivalent.

## Implementation Details
* Converts each decimal digit (0-9) to a 4-bit binary representation
* Uses `fold` with `write!` macro for efficient string building
* Handles negative numbers by treating them as 0 (matching Python implementation)
* Returns result with "0b" prefix for consistency
* Time Complexity: O(n) where n is the number of digits
* Space Complexity: O(n) for the output string

## Examples
```rust
binary_coded_decimal(12)   // Returns "0b00010010" (1=0001, 2=0010)
binary_coded_decimal(987)  // Returns "0b100110000111" (9=1001, 8=1000, 7=0111)
binary_coded_decimal(-5)   // Returns "0b0000" (negative → 0)
```

## Testing
* Added comprehensive unit tests covering:
  * Zero and single digits (0-9)
  * Two-digit numbers
  * Three-digit numbers
  * Large numbers (4+ digits)
  * Negative numbers
  * Specific digit encoding verification
* All tests pass with `cargo test`
* Doctests pass with correct import paths
* Code formatted with `cargo fmt`
* No clippy warnings (uses `fold` and `write!` for efficiency)

## Checklist
- [x] I have tested the code
- [x] I have run `cargo fmt`
- [x] I have run `cargo clippy`
- [x] I have added documentation
- [x] I have added tests