### PR TITLE
feat: add `find_missing_number` function to bit_manipulation

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -1,6 +1,6 @@
 # List of all files
 
-## Src
+## src
   * Backtracking
     * [All Combinations of Size K](https://github.com/TheAlgorithms/Rust/blob/master/src/backtracking/all_combination_of_size_k.rs)
     * [Graph Coloring](https://github.com/TheAlgorithms/Rust/blob/master/src/backtracking/graph_coloring.rs)
@@ -21,6 +21,7 @@
     * [Counting Bits](https://github.com/TheAlgorithms/Rust/blob/master/src/bit_manipulation/counting_bits.rs)
     * [Highest Set Bit](https://github.com/TheAlgorithms/Rust/blob/master/src/bit_manipulation/highest_set_bit.rs)
     * [Is Power of Two](https://github.com/TheAlgorithms/Rust/blob/master/src/bit_manipulation/is_power_of_two.rs)
+    * [Missing Number](https://github.com/TheAlgorithms/Rust/blob/master/src/bit_manipulation/find_missing_number.rs)
     * [N Bits Gray Code](https://github.com/TheAlgorithms/Rust/blob/master/src/bit_manipulation/n_bits_gray_code.rs)
     * [Previous Power of Two](https://github.com/TheAlgorithms/Rust/blob/master/src/bit_manipulation/find_previous_power_of_two.rs)
     * [Reverse Bits](https://github.com/TheAlgorithms/Rust/blob/master/src/bit_manipulation/reverse_bits.rs)

--- a/src/bit_manipulation/find_missing_number.rs
+++ b/src/bit_manipulation/find_missing_number.rs
@@ -1,0 +1,122 @@
+/// Finds the missing number in a slice of consecutive integers.
+///
+/// This function uses XOR bitwise operation to find the missing number.
+/// It XORs all expected numbers in the range [min, max] with the actual
+/// numbers present in the array. Since XOR has the property that `a ^ a = 0`,
+/// all present numbers cancel out, leaving only the missing number.
+///
+/// # Arguments
+///
+/// * `nums` - A slice of integers forming a sequence with one missing number
+///
+/// # Returns
+///
+/// * `Ok(i32)` - The missing number in the sequence
+/// * `Err(String)` - An error message if the input is invalid
+///
+/// # Examples
+///
+/// ```
+/// # use the_algorithms_rust::bit_manipulation::find_missing_number;
+/// assert_eq!(find_missing_number(&[0, 1, 3, 4]).unwrap(), 2);
+/// assert_eq!(find_missing_number(&[4, 3, 1, 0]).unwrap(), 2);
+/// assert_eq!(find_missing_number(&[-4, -3, -1, 0]).unwrap(), -2);
+/// assert_eq!(find_missing_number(&[-2, 2, 1, 3, 0]).unwrap(), -1);
+/// assert_eq!(find_missing_number(&[1, 3, 4, 5, 6]).unwrap(), 2);
+/// ```
+pub fn find_missing_number(nums: &[i32]) -> Result<i32, String> {
+    if nums.is_empty() {
+        return Err("input array must not be empty".to_string());
+    }
+
+    if nums.len() == 1 {
+        return Err("array must have at least 2 elements to find a missing number".to_string());
+    }
+
+    let low = *nums.iter().min().unwrap();
+    let high = *nums.iter().max().unwrap();
+
+    let mut missing_number = high;
+
+    for i in low..high {
+        let index = (i - low) as usize;
+        missing_number ^= i ^ nums[index];
+    }
+
+    Ok(missing_number)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_in_middle() {
+        assert_eq!(find_missing_number(&[0, 1, 3, 4]).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_unordered_array() {
+        assert_eq!(find_missing_number(&[4, 3, 1, 0]).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_negative_numbers() {
+        assert_eq!(find_missing_number(&[-4, -3, -1, 0]).unwrap(), -2);
+    }
+
+    #[test]
+    fn test_negative_and_positive() {
+        assert_eq!(find_missing_number(&[-2, 2, 1, 3, 0]).unwrap(), -1);
+    }
+
+    #[test]
+    fn test_missing_at_start() {
+        assert_eq!(find_missing_number(&[1, 3, 4, 5, 6]).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_unordered_missing_middle() {
+        assert_eq!(find_missing_number(&[6, 5, 4, 2, 1]).unwrap(), 3);
+    }
+
+    #[test]
+    fn test_another_unordered() {
+        assert_eq!(find_missing_number(&[6, 1, 5, 3, 4]).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_empty_array() {
+        assert!(find_missing_number(&[]).is_err());
+        assert_eq!(
+            find_missing_number(&[]).unwrap_err(),
+            "input array must not be empty"
+        );
+    }
+
+    #[test]
+    fn test_single_element() {
+        assert!(find_missing_number(&[5]).is_err());
+        assert_eq!(
+            find_missing_number(&[5]).unwrap_err(),
+            "array must have at least 2 elements to find a missing number"
+        );
+    }
+
+    #[test]
+    fn test_two_elements() {
+        assert_eq!(find_missing_number(&[0, 2]).unwrap(), 1);
+        assert_eq!(find_missing_number(&[2, 0]).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_large_range() {
+        assert_eq!(find_missing_number(&[100, 101, 103, 104]).unwrap(), 102);
+    }
+
+    #[test]
+    fn test_missing_at_boundaries() {
+        // Missing is the second to last element
+        assert_eq!(find_missing_number(&[1, 2, 3, 5]).unwrap(), 4);
+    }
+}

--- a/src/bit_manipulation/mod.rs
+++ b/src/bit_manipulation/mod.rs
@@ -1,6 +1,7 @@
 mod binary_coded_decimal;
 mod binary_count_trailing_zeros;
 mod counting_bits;
+mod find_missing_number;
 mod find_previous_power_of_two;
 mod highest_set_bit;
 mod is_power_of_two;
@@ -13,6 +14,7 @@ mod twos_complement;
 pub use self::binary_coded_decimal::binary_coded_decimal;
 pub use self::binary_count_trailing_zeros::binary_count_trailing_zeros;
 pub use self::counting_bits::count_set_bits;
+pub use self::find_missing_number::find_missing_number;
 pub use self::find_previous_power_of_two::find_previous_power_of_two;
 pub use self::highest_set_bit::find_highest_set_bit;
 pub use self::is_power_of_two::is_power_of_two;


### PR DESCRIPTION
## Description
Adds a new function `find_missing_number` to the bit_manipulation module that finds the missing number in an array of consecutive integers.

## Algorithm
Uses XOR bitwise operation to efficiently find the missing number:
1. Finds the minimum and maximum values in the array
2. XORs all expected numbers in the range [min, max] with actual numbers
3. Since `a ^ a = 0`, all present numbers cancel out, leaving only the missing number

## Implementation Details
- **Time Complexity**: $O(n)$ - single pass to find min/max, then $O(n)$ for XOR operations
- **Space Complexity**: $O(1)$ - constant extra space
- Works with:
  - Unordered arrays
  - Negative numbers
  - Mixed positive and negative ranges
- Proper error handling for edge cases (empty array, single element)

## Examples
```rust
find_missing_number(&[0, 1, 3, 4]) // Returns 2
find_missing_number(&[-4, -3, -1, 0]) // Returns -2
find_missing_number(&[4, 3, 1, 0]) // Returns 2 (works with unordered)
```

## Testing
- ✅ All existing tests pass
- ✅ New tests added for:
  - Missing number in middle of sequence
  - Unordered arrays
  - Negative numbers
  - Mixed negative and positive numbers
  - Edge cases (empty array, single element, two elements)
  - Large ranges
  - Missing at boundaries

## Checklist
- [x] Code follows Rust style guidelines (`cargo fmt`)
- [x] Passes clippy lints (`cargo clippy`)
- [x] All tests pass (`cargo test`)
- [x] Documentation includes examples
- [x] Function is properly exported in module
- [x] Error handling implemented for invalid inputs
- [x] Works with negative numbers and unordered arrays