### PR TITLE
Add strand sort

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -381,6 +381,7 @@
     * [Sleep Sort](https://github.com/TheAlgorithms/Rust/blob/master/src/sorting/sleep_sort.rs)
     * [Sort Utils](https://github.com/TheAlgorithms/Rust/blob/master/src/sorting/sort_utils.rs)
     * [Stooge Sort](https://github.com/TheAlgorithms/Rust/blob/master/src/sorting/stooge_sort.rs)
+    * [Strand Sort](https://github.com/TheAlgorithms/Rust/blob/master/src/sorting/strand_sort.rs)
     * [Tim Sort](https://github.com/TheAlgorithms/Rust/blob/master/src/sorting/tim_sort.rs)
     * [Tree Sort](https://github.com/TheAlgorithms/Rust/blob/master/src/sorting/tree_sort.rs)
     * [Wave Sort](https://github.com/TheAlgorithms/Rust/blob/master/src/sorting/wave_sort.rs)

--- a/src/sorting/mod.rs
+++ b/src/sorting/mod.rs
@@ -29,6 +29,7 @@ mod sleep_sort;
 #[cfg(test)]
 mod sort_utils;
 mod stooge_sort;
+mod strand_sort;
 mod tim_sort;
 mod tree_sort;
 mod wave_sort;
@@ -65,6 +66,7 @@ pub use self::selection_sort::selection_sort;
 pub use self::shell_sort::shell_sort;
 pub use self::sleep_sort::sleep_sort;
 pub use self::stooge_sort::stooge_sort;
+pub use self::strand_sort::strand_sort;
 pub use self::tim_sort::tim_sort;
 pub use self::tree_sort::tree_sort;
 pub use self::wave_sort::wave_sort;

--- a/src/sorting/strand_sort.rs
+++ b/src/sorting/strand_sort.rs
@@ -1,0 +1,118 @@
+pub fn strand_sort<T: Ord + Clone>(arr: &mut [T]) {
+    if arr.len() <= 1 {
+        return;
+    }
+
+    let mut result: Vec<T> = Vec::new();
+    let mut input: Vec<T> = arr.to_vec();
+
+    while !input.is_empty() {
+        let mut sublist: Vec<T> = Vec::new();
+        let mut leftovers: Vec<T> = Vec::with_capacity(input.len());
+
+        for item in input {
+            if sublist.is_empty() || item >= *sublist.last().unwrap() {
+                sublist.push(item);
+            } else {
+                leftovers.push(item);
+            }
+        }
+
+        result = merge(result, sublist);
+        input = leftovers;
+    }
+
+    arr.clone_from_slice(&result);
+}
+
+fn merge<T: Ord + Clone>(left: Vec<T>, right: Vec<T>) -> Vec<T> {
+    let mut merged = Vec::with_capacity(left.len() + right.len());
+    let mut left_iter = left.into_iter().peekable();
+    let mut right_iter = right.into_iter().peekable();
+
+    loop {
+        match (left_iter.peek(), right_iter.peek()) {
+            (Some(l), Some(r)) => {
+                if l <= r {
+                    merged.push(left_iter.next().unwrap());
+                } else {
+                    merged.push(right_iter.next().unwrap());
+                }
+            }
+            (Some(_), None) => {
+                merged.extend(left_iter);
+                break;
+            }
+            (None, Some(_)) => {
+                merged.extend(right_iter);
+                break;
+            }
+            (None, None) => break,
+        }
+    }
+
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sorting::have_same_elements;
+    use crate::sorting::is_sorted;
+
+    #[test]
+    fn basic() {
+        let mut res = vec![10, 8, 4, 3, 1, 9, 2, 7, 5, 6];
+        let cloned = res.clone();
+        strand_sort(&mut res);
+        assert!(is_sorted(&res) && have_same_elements(&res, &cloned));
+    }
+
+    #[test]
+    fn basic_string() {
+        let mut res = vec!["a", "bb", "d", "cc"];
+        let cloned = res.clone();
+        strand_sort(&mut res);
+        assert!(is_sorted(&res) && have_same_elements(&res, &cloned));
+    }
+
+    #[test]
+    fn empty() {
+        let mut res = Vec::<u8>::new();
+        let cloned = res.clone();
+        strand_sort(&mut res);
+        assert!(is_sorted(&res) && have_same_elements(&res, &cloned));
+    }
+
+    #[test]
+    fn one_element() {
+        let mut res = vec![1];
+        let cloned = res.clone();
+        strand_sort(&mut res);
+        assert!(is_sorted(&res) && have_same_elements(&res, &cloned));
+    }
+
+    #[test]
+    fn pre_sorted() {
+        let mut res = vec![1, 2, 3, 4];
+        let cloned = res.clone();
+        strand_sort(&mut res);
+        assert!(is_sorted(&res) && have_same_elements(&res, &cloned));
+    }
+
+    #[test]
+    fn reverse_sorted() {
+        let mut res = vec![4, 3, 2, 1];
+        let cloned = res.clone();
+        strand_sort(&mut res);
+        assert!(is_sorted(&res) && have_same_elements(&res, &cloned));
+    }
+
+    #[test]
+    fn duplicates() {
+        let mut res = vec![4, 2, 4, 3, 2, 1, 4];
+        let cloned = res.clone();
+        strand_sort(&mut res);
+        assert!(is_sorted(&res) && have_same_elements(&res, &cloned));
+    }
+}

--- a/src/sorting/strand_sort.rs
+++ b/src/sorting/strand_sort.rs
@@ -30,16 +30,11 @@ fn merge<T: Ord + Clone>(left: Vec<T>, right: Vec<T>) -> Vec<T> {
     let mut left_iter = left.into_iter().peekable();
     let mut right_iter = right.into_iter().peekable();
 
-    loop {
-        match (left_iter.peek(), right_iter.peek()) {
-            (Some(l), Some(r)) => {
-                if l <= r {
-                    merged.push(left_iter.next().unwrap());
-                } else {
-                    merged.push(right_iter.next().unwrap());
-                }
-            }
-            _ => break,
+    while let (Some(l), Some(r)) = (left_iter.peek(), right_iter.peek()) {
+        if l <= r {
+            merged.push(left_iter.next().unwrap());
+        } else {
+            merged.push(right_iter.next().unwrap());
         }
     }
 

--- a/src/sorting/strand_sort.rs
+++ b/src/sorting/strand_sort.rs
@@ -39,17 +39,12 @@ fn merge<T: Ord + Clone>(left: Vec<T>, right: Vec<T>) -> Vec<T> {
                     merged.push(right_iter.next().unwrap());
                 }
             }
-            (Some(_), None) => {
-                merged.extend(left_iter);
-                break;
-            }
-            (None, Some(_)) => {
-                merged.extend(right_iter);
-                break;
-            }
-            (None, None) => break,
+            _ => break,
         }
     }
+
+    merged.extend(left_iter);
+    merged.extend(right_iter);
 
     merged
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Added the Strand Sort algorithm to the sorting module. Strand sort is a recursive/iterative sorting algorithm that sorts items of a list into increasing order. It works by repeatedly pulling sorted sublists out of the list and merging them with a sorted result list. The implementation provided ensures $O(N)$ best-case time complexity, where elements are already sorted or reverse-sorted, and $O(N^2)$ worst-case time complexity.

References:
- [Strand sort - Wikipedia](https://en.wikipedia.org/wiki/Strand_sort)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `CONTRIBUTING.md` and my code follows its guidelines.
