### PR TITLE
chore: resolve and suppress new warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,7 @@ unwrap_used = { level = "allow", priority = 1 }
 use_debug = { level = "allow", priority = 1 }
 used_underscore_items = { level = "allow", priority = 1 }
 wildcard_enum_match_arm = { level = "allow", priority = 1 }
+needless_for_each = { level = "allow", priority = 1 }
 # style-lints:
 doc_lazy_continuation = { level = "allow", priority = 1 }
 doc_overindented_list_items = { level = "allow", priority = 1 }

--- a/src/bit_manipulation/binary_count_trailing_zeros.rs
+++ b/src/bit_manipulation/binary_count_trailing_zeros.rs
@@ -50,7 +50,7 @@ pub fn binary_count_trailing_zeros_bitwise(num: u64) -> u32 {
     }
 
     let rightmost_set_bit = num & (num.wrapping_neg());
-    63 - rightmost_set_bit.leading_zeros()
+    rightmost_set_bit.ilog2()
 }
 
 #[cfg(test)]

--- a/src/math/prime_check.rs
+++ b/src/math/prime_check.rs
@@ -1,5 +1,5 @@
 pub fn prime_check(num: usize) -> bool {
-    if (num > 1) & (num < 4) {
+    if (num > 1) && (num < 4) {
         return true;
     } else if (num < 2) || (num.is_multiple_of(2)) {
         return false;


### PR DESCRIPTION
# Pull Request Template

## Description

This PR suppresses new clippy lints and resolved new errors.
Similar to:
- #754
- #845
- #865
- #871
- #877
- #883
- #895
- #905
## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
