### PR TITLE
feat: add Fletcher checksum to hashing

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -214,6 +214,7 @@
     * [Stable Matching](https://github.com/TheAlgorithms/Rust/blob/master/src/greedy/stable_matching.rs)
   * Hashing
     * [Blake2B](https://github.com/TheAlgorithms/Rust/blob/master/src/hashing/blake2b.rs)
+    * [Fletcher](https://github.com/TheAlgorithms/Rust/blob/master/src/hashing/fletcher.rs)
     * [Hashing Traits](https://github.com/TheAlgorithms/Rust/blob/master/src/hashing/hashing_traits.rs)
     * [MD5](https://github.com/TheAlgorithms/Rust/blob/master/src/hashing/md5.rs)
     * [SHA-1](https://github.com/TheAlgorithms/Rust/blob/master/src/hashing/sha1.rs)

--- a/src/hashing/fletcher.rs
+++ b/src/hashing/fletcher.rs
@@ -1,0 +1,77 @@
+//! The Fletcher checksum is an algorithm for computing a position-dependent
+//! checksum devised by John G. Fletcher (1934–2012) at Lawrence Livermore Labs
+//! in the late 1970s. The objective of the Fletcher checksum was to provide
+//! error-detection properties approaching those of a cyclic redundancy check
+//! but with the lower computational effort associated with summation techniques.
+//!
+//! Reference: <https://en.wikipedia.org/wiki/Fletcher%27s_checksum>
+
+/// Computes the Fletcher-16 checksum of an ASCII string.
+///
+/// Iterates over every byte in the input, maintaining two running sums
+/// (`sum1` and `sum2`) each reduced modulo 255. The final 16-bit checksum
+/// is produced by packing `sum2` into the high byte and `sum1` into the low byte.
+///
+/// # Arguments
+///
+/// * `data` - An ASCII string slice to checksum.
+///
+/// # Returns
+///
+/// A `u16` containing the Fletcher-16 checksum.
+///
+/// # Examples
+///
+/// ```
+/// use the_algorithms_rust::hashing::fletcher;
+///
+/// assert_eq!(fletcher("hello world"), 6752);
+/// assert_eq!(fletcher("onethousandfourhundredthirtyfour"), 28347);
+/// assert_eq!(fletcher("The quick brown fox jumps over the lazy dog."), 5655);
+/// ```
+pub fn fletcher(data: &str) -> u16 {
+    let mut sum1: u16 = 0;
+    let mut sum2: u16 = 0;
+
+    for byte in data.bytes() {
+        sum1 = (sum1 + byte as u16) % 255;
+        sum2 = (sum2 + sum1) % 255;
+    }
+
+    (sum2 << 8) | sum1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hello_world() {
+        assert_eq!(fletcher("hello world"), 6752);
+    }
+
+    #[test]
+    fn test_long_word() {
+        assert_eq!(fletcher("onethousandfourhundredthirtyfour"), 28347);
+    }
+
+    #[test]
+    fn test_pangram() {
+        assert_eq!(
+            fletcher("The quick brown fox jumps over the lazy dog."),
+            5655
+        );
+    }
+
+    #[test]
+    fn test_empty_string() {
+        assert_eq!(fletcher(""), 0);
+    }
+
+    #[test]
+    fn test_single_char() {
+        // 'A' = 65; sum1 = 65 % 255 = 65, sum2 = 65 % 255 = 65
+        // result = (65 << 8) | 65 = 16705
+        assert_eq!(fletcher("A"), 16705);
+    }
+}

--- a/src/hashing/mod.rs
+++ b/src/hashing/mod.rs
@@ -1,4 +1,5 @@
 mod blake2b;
+mod fletcher;
 mod hashing_traits;
 mod md5;
 mod sha1;
@@ -6,6 +7,7 @@ mod sha2;
 mod sha3;
 
 pub use self::blake2b::blake2b;
+pub use self::fletcher::fletcher;
 pub use self::hashing_traits::{Hasher, HMAC};
 pub use self::md5::{md5, md5_hex};
 pub use self::sha1::sha1;


### PR DESCRIPTION
## Description

Adds an implementation of the **Fletcher-16 checksum** algorithm to `src/hashing/`.

Fletcher's checksum is a position-dependent checksum devised by John G. Fletcher (1934–2012) at Lawrence Livermore Labs in the late 1970s. It provides error-detection properties approaching those of a CRC but with lower computational effort, by maintaining two running sums (`sum1`, `sum2`) each reduced modulo 255, then packing them into a single 16-bit value.

Reference: [Fletcher's Checksum — Wikipedia](https://en.wikipedia.org/wiki/Fletcher%27s_checksum)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `CONTRIBUTING.md` and my code follows its guidelines.