### PR TITLE
chore: resolve new clippy warnings

### DIFF
--- a/src/graph/lowest_common_ancestor.rs
+++ b/src/graph/lowest_common_ancestor.rs
@@ -205,7 +205,7 @@ mod tests {
             }
         }
         let mut offline_answers = offline.answer_queries(1, &tree);
-        offline_answers.sort_unstable_by(|a1, a2| a1.query_id.cmp(&a2.query_id));
+        offline_answers.sort_unstable_by_key(|a| a.query_id);
         assert_eq!(offline_answers, online_answers);
     }
 }

--- a/src/greedy/job_sequencing.rs
+++ b/src/greedy/job_sequencing.rs
@@ -85,7 +85,7 @@ pub fn schedule_jobs(mut jobs: Vec<Job>) -> ScheduleResult {
     }
 
     // Step 1 – sort jobs by profit, highest first.
-    jobs.sort_unstable_by(|a, b| b.profit.cmp(&a.profit));
+    jobs.sort_unstable_by_key(|a| std::cmp::Reverse(a.profit));
 
     // Step 2 – allocate slots.
     // At most n jobs can ever be scheduled, so cap the slot count at jobs.len()

--- a/src/string/burrows_wheeler_transform.rs
+++ b/src/string/burrows_wheeler_transform.rs
@@ -26,7 +26,7 @@ pub fn inv_burrows_wheeler_transform<T: AsRef<str>>(input: (T, usize)) -> String
         table.push((i, input.0.as_ref().chars().nth(i).unwrap()));
     }
 
-    table.sort_by(|a, b| a.1.cmp(&b.1));
+    table.sort_by_key(|a| a.1);
 
     let mut decoded = String::new();
     let mut idx = input.1;

--- a/src/string/manacher.rs
+++ b/src/string/manacher.rs
@@ -54,8 +54,7 @@ pub fn manacher(s: String) -> String {
         radius += 1;
         // 2: Checking palindrome.
         // Need to care about overflow usize.
-        while i >= radius && i + radius <= chars.len() - 1 && chars[i - radius] == chars[i + radius]
-        {
+        while i >= radius && i + radius < chars.len() && chars[i - radius] == chars[i + radius] {
             length_of_palindrome[i] += 2;
             radius += 1;
         }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR suppresses new clippy lints and resolved new errors.
Similar to:
- #754
- #845
- #865
- #871
- #877
- #883
- #895
- #905
- #1029
## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
