### PR TITLE
chore: resolve and suppress new clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,8 @@ use_debug = { level = "allow", priority = 1 }
 used_underscore_items = { level = "allow", priority = 1 }
 wildcard_enum_match_arm = { level = "allow", priority = 1 }
 needless_for_each = { level = "allow", priority = 1 }
+inline_modules = { level = "allow", priority = 1 }
+inline_trait_bounds = { level = "allow", priority = 1 }
 # style-lints:
 doc_lazy_continuation = { level = "allow", priority = 1 }
 doc_overindented_list_items = { level = "allow", priority = 1 }

--- a/src/ciphers/aes.rs
+++ b/src/ciphers/aes.rs
@@ -434,7 +434,7 @@ fn transpose_block(block: &mut [u8]) {
 }
 
 fn bytes_to_word(bytes: &[Byte]) -> Word {
-    assert!(bytes.len() == AES_WORD_SIZE);
+    assert_eq!(bytes.len(), AES_WORD_SIZE);
     let mut word = 0;
     for (i, &byte) in bytes.iter().enumerate() {
         word |= (byte as Word) << (8 * i);

--- a/src/conversions/binary_to_decimal.rs
+++ b/src/conversions/binary_to_decimal.rs
@@ -9,11 +9,8 @@ pub fn binary_to_decimal(binary: &str) -> Option<u128> {
     for bit in binary.chars().rev() {
         match bit {
             '1' => {
-                if let Some(sum) = num.checked_add(&idx_val) {
-                    num = sum;
-                } else {
-                    return None;
-                }
+                let sum = num.checked_add(&idx_val)?;
+                num = sum;
             }
             '0' => {}
             _ => return None,

--- a/src/data_structures/probabilistic/bloom_filter.rs
+++ b/src/data_structures/probabilistic/bloom_filter.rs
@@ -67,6 +67,7 @@ struct SingleBinaryBloomFilter {
 }
 
 /// Given a value and a hash function, compute the hash and return the bit mask
+#[allow(dead_code)]
 fn mask_128<T: Hash>(hasher: &mut DefaultHasher, item: T) -> u128 {
     item.hash(hasher);
     let idx = (hasher.finish() % 128) as u32;

--- a/src/data_structures/veb_tree.rs
+++ b/src/data_structures/veb_tree.rs
@@ -256,11 +256,11 @@ mod test {
         elements.sort();
         elements.dedup();
         for (i, element) in tree.iter().enumerate() {
-            assert!(elements[i] == element);
+            assert_eq!(elements[i], element);
         }
         for i in 1..elements.len() {
-            assert!(tree.succ(elements[i - 1]) == Some(elements[i]));
-            assert!(tree.pred(elements[i]) == Some(elements[i - 1]));
+            assert_eq!(tree.succ(elements[i - 1]), Some(elements[i]));
+            assert_eq!(tree.pred(elements[i]), Some(elements[i - 1]));
         }
     }
 

--- a/src/graph/bipartite_matching.rs
+++ b/src/graph/bipartite_matching.rs
@@ -241,7 +241,7 @@ mod tests {
         g.print_matching();
         assert_eq!(g.mt2[1], 1);
         for i in 2..g.mt2.len() {
-            assert!(g.mt2[i] == -1);
+            assert_eq!(g.mt2[i], -1);
         }
     }
     #[test]
@@ -264,7 +264,7 @@ mod tests {
         g.print_matching();
         assert_eq!(g.mt2[1], 1);
         for i in 2..g.mt2.len() {
-            assert!(g.mt2[i] == -1);
+            assert_eq!(g.mt2[i], -1);
         }
     }
 }

--- a/src/graph/depth_first_search_tic_tac_toe.rs
+++ b/src/graph/depth_first_search_tic_tac_toe.rs
@@ -313,7 +313,7 @@ fn append_playaction(
 
         //No change hence append only
         (_, _, _) => {
-            assert!(play_actions.side == appendee.side);
+            assert_eq!(play_actions.side, appendee.side);
             play_actions.positions.push(appendee.position);
         }
     }

--- a/src/hashing/sha3.rs
+++ b/src/hashing/sha3.rs
@@ -264,7 +264,7 @@ fn h2b(h: &[u8], n: usize) -> Vec<bool> {
         }
     }
 
-    assert!(bits.len() == h.len() * U8BITS);
+    assert_eq!(bits.len(), h.len() * U8BITS);
 
     bits.truncate(n);
     bits


### PR DESCRIPTION
# Pull Request Template

## Description

This PR suppresses new clippy lints and resolved new errors.
Similar to:
- #754
- #845
- #865
- #871
- #877
- #883
- #895
- #905
- #1029
- #1040
## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or
try to optimize your code or make the test easier to run. We have this rule because we have hundreds of
tests to run; If each one of them took 300ms, we would have to wait for a long time.
