### PR TITLE
fix: empty slice panics in bead_sort, bogo_sort, comb_sort and wave_sort

### DIFF
--- a/src/sorting/bead_sort.rs
+++ b/src/sorting/bead_sort.rs
@@ -1,6 +1,11 @@
 //Bead sort only works for sequences of non-negative integers.
 //https://en.wikipedia.org/wiki/Bead_sort
 pub fn bead_sort(a: &mut [usize]) {
+    // An empty slice has no maximum to seed the bead grid with.
+    if a.is_empty() {
+        return;
+    }
+
     // Find the maximum element
     let mut max = a[0];
     (1..a.len()).for_each(|i| {
@@ -55,5 +60,29 @@ mod tests {
         let cloned = ve2;
         bead_sort(&mut ve2);
         assert!(is_sorted(&ve2) && have_same_elements(&ve2, &cloned));
+    }
+
+    #[test]
+    fn empty() {
+        let mut ve3: Vec<usize> = vec![];
+        let cloned = ve3.clone();
+        bead_sort(&mut ve3);
+        assert!(is_sorted(&ve3) && have_same_elements(&ve3, &cloned));
+    }
+
+    #[test]
+    fn one_element() {
+        let mut ve4: [usize; 1] = [4];
+        let cloned = ve4;
+        bead_sort(&mut ve4);
+        assert!(is_sorted(&ve4) && have_same_elements(&ve4, &cloned));
+    }
+
+    #[test]
+    fn all_zeroes() {
+        let mut ve5: [usize; 3] = [0, 0, 0];
+        let cloned = ve5;
+        bead_sort(&mut ve5);
+        assert!(is_sorted(&ve5) && have_same_elements(&ve5, &cloned));
     }
 }

--- a/src/sorting/bogo_sort.rs
+++ b/src/sorting/bogo_sort.rs
@@ -4,13 +4,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const DEFAULT: u64 = 4294967296;
 
 fn is_sorted<T: Ord>(arr: &[T], len: usize) -> bool {
-    for i in 0..len - 1 {
-        if arr[i] > arr[i + 1] {
-            return false;
-        }
-    }
-
-    true
+    // `windows` yields nothing below two elements, where `0..len - 1` underflowed.
+    arr[..len].windows(2).all(|pair| pair[0] <= pair[1])
 }
 
 #[cfg(target_pointer_width = "64")]
@@ -69,5 +64,19 @@ mod tests {
         for i in 0..arr.len() - 1 {
             assert!(arr[i] <= arr[i + 1]);
         }
+    }
+
+    #[test]
+    fn empty() {
+        let mut arr: Vec<i32> = vec![];
+        bogo_sort(&mut arr);
+        assert!(arr.is_empty());
+    }
+
+    #[test]
+    fn one_element() {
+        let mut arr = [7];
+        bogo_sort(&mut arr);
+        assert_eq!(&arr, &[7]);
     }
 }

--- a/src/sorting/comb_sort.rs
+++ b/src/sorting/comb_sort.rs
@@ -1,4 +1,10 @@
 pub fn comb_sort<T: Ord>(arr: &mut [T]) {
+    // `gap` is clamped to at least 1 below, so `arr.len() - gap` would underflow
+    // on an empty slice.
+    if arr.len() < 2 {
+        return;
+    }
+
     let mut gap = arr.len();
     let shrink = 1.3;
     let mut sorted = false;
@@ -50,5 +56,21 @@ mod tests {
         let cloned = ve3.clone();
         comb_sort(&mut ve3);
         assert!(is_sorted(&ve3) && have_same_elements(&ve3, &cloned));
+    }
+
+    #[test]
+    fn empty() {
+        let mut ve4: Vec<u8> = vec![];
+        let cloned = ve4.clone();
+        comb_sort(&mut ve4);
+        assert!(is_sorted(&ve4) && have_same_elements(&ve4, &cloned));
+    }
+
+    #[test]
+    fn one_element() {
+        let mut ve5 = vec![3];
+        let cloned = ve5.clone();
+        comb_sort(&mut ve5);
+        assert!(is_sorted(&ve5) && have_same_elements(&ve5, &cloned));
     }
 }

--- a/src/sorting/wave_sort.rs
+++ b/src/sorting/wave_sort.rs
@@ -19,7 +19,8 @@ pub fn wave_sort<T: Ord>(arr: &mut [T]) {
     let n = arr.len();
     arr.sort();
 
-    for i in (0..n - 1).step_by(2) {
+    // `saturating_sub` keeps an empty slice from underflowing to `usize::MAX`.
+    for i in (0..n.saturating_sub(1)).step_by(2) {
         arr.swap(i, i + 1);
     }
 }
@@ -66,5 +67,19 @@ mod tests {
         wave_sort(&mut array);
         let expected = vec![10, 5, 20, 15, 25];
         assert_eq!(&array, &expected);
+    }
+
+    #[test]
+    fn empty() {
+        let mut array: Vec<i32> = vec![];
+        wave_sort(&mut array);
+        assert!(array.is_empty());
+    }
+
+    #[test]
+    fn one_element() {
+        let mut array = vec![42];
+        wave_sort(&mut array);
+        assert_eq!(&array, &[42]);
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Four algorithms in `src/sorting/` panic when handed an empty slice. Sorting nothing should
be a no-op, and the other 30 sorts in the module already treat it that way — 20 of them have
an explicit `empty()` test. These four were simply never exercised on that input.

```rust
sorting::bead_sort(&mut []);                 // index out of bounds: the len is 0 but the index is 0
sorting::bogo_sort(&mut [] as &mut [i32]);   // attempt to subtract with overflow
sorting::comb_sort(&mut [] as &mut [i32]);   // attempt to subtract with overflow
sorting::wave_sort(&mut [] as &mut [i32]);   // attempt to subtract with overflow
```

Each is an unsigned underflow or an unchecked first-element read:

* **`bead_sort`** — `let mut max = a[0];` reads element `0` before checking the slice is
  non-empty. Now returns early; there is no bead grid to build.
* **`bogo_sort`** — the private `is_sorted` helper loops `for i in 0..len - 1`, which
  underflows to `usize::MAX` at `len == 0`. Rewritten with `windows(2)`, which naturally
  yields nothing below two elements. This also drops a hand-rolled loop in favour of the
  same idiom `sorting::is_sorted` already uses.
* **`comb_sort`** — `gap` is clamped to a minimum of `1`, so `for i in 0..arr.len() - gap`
  underflows at `arr.len() == 0`. Now returns early for fewer than two elements.
* **`wave_sort`** — `for i in (0..n - 1).step_by(2)` underflows at `n == 0`. Now uses
  `n.saturating_sub(1)`.

These are release-mode hazards as well as debug-mode panics: with overflow checks off, the
underflowed bound becomes a near-`usize::MAX` loop bound and the sort runs off the end of
the slice.

### Tests

`empty` and `one_element` cases added to all four, following the module's existing
convention of asserting with the shared `is_sorted` / `have_same_elements` helpers.
`bead_sort` also gains an `all_zeroes` case, since a maximum of `0` is the other way its
bead grid can end up with zero columns. All new tests run in well under 300ms.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

> Note: no `mod.rs` or `DIRECTORY.md` change was needed — this fixes existing entries rather
> than adding a new algorithm.
