### PR TITLE
fix: burrows_wheeler_transform round-trip corruption and unicode panic

### DIFF
--- a/src/string/burrows_wheeler_transform.rs
+++ b/src/string/burrows_wheeler_transform.rs
@@ -1,17 +1,30 @@
+//! Burrows-Wheeler transform.
+//!
+//! The transform sorts every rotation of the input and emits the last character
+//! of each. Inversion relies on that rotation order being *the same total order*
+//! the inverse uses to sort the encoded characters, so both directions here order
+//! by `char` (equivalently, by code point).
+//!
+//! Wikipedia reference: <https://en.wikipedia.org/wiki/Burrows%E2%80%93Wheeler_transform>
+
+/// Returns the transformed string together with the row index of the original input.
 pub fn burrows_wheeler_transform(input: &str) -> (String, usize) {
-    let len = input.len();
+    // Rotate over `char`s: slicing `&str` by an arbitrary index splits multi-byte
+    // characters and panics.
+    let chars: Vec<char> = input.chars().collect();
+    let len = chars.len();
 
     let mut table = Vec::<String>::with_capacity(len);
     for i in 0..len {
-        table.push(input[i..].to_owned() + &input[..i]);
+        table.push(chars[i..].iter().chain(&chars[..i]).collect());
     }
-    table.sort_by_key(|a| a.to_lowercase());
+    table.sort();
 
     let mut encoded = String::new();
     let mut index: usize = 0;
     for (i, item) in table.iter().enumerate().take(len) {
         encoded.push(item.chars().last().unwrap());
-        if item.eq(&input) {
+        if item == input {
             index = i;
         }
     }
@@ -19,13 +32,14 @@ pub fn burrows_wheeler_transform(input: &str) -> (String, usize) {
     (encoded, index)
 }
 
+/// Reconstructs the original string from a transform and its row index.
 pub fn inv_burrows_wheeler_transform<T: AsRef<str>>(input: (T, usize)) -> String {
-    let len = input.0.as_ref().len();
-    let mut table = Vec::<(usize, char)>::with_capacity(len);
-    for i in 0..len {
-        table.push((i, input.0.as_ref().chars().nth(i).unwrap()));
-    }
+    let chars: Vec<char> = input.0.as_ref().chars().collect();
+    let len = chars.len();
 
+    // `sort_by_key` is stable, which is what keeps equal characters in their
+    // original relative order — the property the reconstruction walk depends on.
+    let mut table: Vec<(usize, char)> = chars.into_iter().enumerate().collect();
     table.sort_by_key(|a| a.1);
 
     let mut decoded = String::new();
@@ -113,5 +127,61 @@ mod tests {
             inv_burrows_wheeler_transform(burrows_wheeler_transform("")),
             ""
         );
+    }
+
+    /// Regression: the forward transform sorted rotations case-insensitively
+    /// while the inverse sorted characters by code point, so any string mixing
+    /// cases round-tripped to garbage ("Hello" came back as "elloe").
+    #[test]
+    fn mixed_case() {
+        for text in [
+            "Hello",
+            "Mississippi",
+            "AaAa",
+            "Test",
+            "aAbB",
+            "Rust Lang",
+            "The Algorithms",
+        ] {
+            assert_eq!(
+                inv_burrows_wheeler_transform(burrows_wheeler_transform(text)),
+                text
+            );
+        }
+    }
+
+    /// Regression: rotations were built by slicing `&str` at byte offsets, which
+    /// panics as soon as an index lands inside a multi-byte character.
+    #[test]
+    fn unicode() {
+        for text in [
+            "café au lait",
+            "日本語のテキスト",
+            "naïve",
+            "ábcábc",
+            "🎉party🎉",
+            "Ünïcödé Mïx",
+        ] {
+            assert_eq!(
+                inv_burrows_wheeler_transform(burrows_wheeler_transform(text)),
+                text
+            );
+        }
+    }
+
+    #[test]
+    fn single_character() {
+        assert_eq!(burrows_wheeler_transform("a"), ("a".to_owned(), 0));
+        assert_eq!(inv_burrows_wheeler_transform(("a", 0usize)), "a");
+    }
+
+    #[test]
+    fn repeated_characters() {
+        for text in ["aaaa", "abab", "aaaab"] {
+            assert_eq!(
+                inv_burrows_wheeler_transform(burrows_wheeler_transform(text)),
+                text
+            );
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

`burrows_wheeler_transform` and `inv_burrows_wheeler_transform` sort by two different
orderings, so the transform is **not reversible for any input that mixes upper and lower
case**. No error is raised — the inverse simply returns a different string:

```rust
let encoded = burrows_wheeler_transform("Hello");        // ("Hoell", 1)
inv_burrows_wheeler_transform(encoded);                  // "elloe"  -- expected "Hello"

inv_burrows_wheeler_transform(burrows_wheeler_transform("Mississippi"));
// "issippMissi" -- expected "Mississippi"
```

### Why it happens

Inverting a BWT works only when the forward rotation sort and the inverse's character sort
are **the same total order**. They were not:

* the forward transform sorted rotations with `sort_by_key(|a| a.to_lowercase())`, i.e.
  case-insensitively;
* the inverse sorted the encoded characters with `sort_by_key(|a| a.1)`, i.e. by code point.

For `"Hello"` the two disagree immediately:

```text
forward sort (to_lowercase): ["elloH", "Hello", "lloHe", "loHel", "oHell"]
plain lexicographic sort:    ["Hello", "elloH", "lloHe", "loHel", "oHell"]
inverse sorts chars as:      ['H', 'e', 'l', 'l', 'o']   // 'H' = 72 before 'e' = 101
```

Dropping `.to_lowercase()` makes the forward sort plain lexicographic. Rust compares `String`
bytewise and UTF-8 byte order matches code-point order, so the forward sort now agrees with
the inverse's `char` sort exactly. The existing expectations are unaffected because every
test string was single-case (`"CARROT"`, `"THEALGORITHMS"`) or punctuation, where
`to_lowercase()` is a no-op on the ordering.

### Rotations were also built by slicing at byte offsets

`input[i..].to_owned() + &input[..i]` indexes a `&str` by an arbitrary `i`, which panics as
soon as the index lands inside a multi-byte character:

```rust
burrows_wheeler_transform("café au lait");
// panicked: byte index 4 is not a char boundary; it is inside 'é' (bytes 3..5)
```

Rotations are now built from a `Vec<char>`, so every index is a character position.
`inv_burrows_wheeler_transform` got the matching treatment: it used `input.len()` (a **byte**
count) to drive a loop that indexed by character, and called `chars().nth(i)` inside that
loop, which is a quadratic scan. Both are gone.

The stability of `sort_by_key` in the inverse is what keeps equal characters in their original
relative order, which the reconstruction walk depends on; that is now stated in a comment so
it does not get "optimised" into `sort_unstable_by_key` later.

### Tests

Added `mixed_case` (7 strings that all round-tripped to garbage before), `unicode` (6 strings
that all panicked before), `single_character` and `repeated_characters`. The existing tests
are unchanged and still pass. All run in well under 300ms.

Note: `src/compression/burrows_wheeler_transform.rs` is a separate implementation and does
**not** have this bug — it sorts consistently in both directions. It is untouched here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warnings` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I added my algorithm to the corresponding `mod.rs` file within its own folder, and in any parent folder(s).
- [x] I added my algorithm to `DIRECTORY.md` with the correct link.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

> Note: no `mod.rs` or `DIRECTORY.md` change was needed — this fixes an existing entry rather
> than adding a new algorithm.
